### PR TITLE
Convert emp type

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
-// Components
 import BaseDialog from "./components/baseDialog/BaseDialog.vue";
-// import AssignManager from "./components/baseDialog/dialogContent/AssignManager.vue";
-// import ConvertEmployeeType from "./components/baseDialog/dialogContent/ConvertEmployeeType.vue";
-// import RehireEmployee from "./components/baseDialog/dialogContent/RehireEmployee.vue";
 import { dialogRegistry, dialogMeta } from "./components/baseDialog/registry";
 import { useDialogStore } from "./stores/dialog";
 
@@ -93,15 +89,6 @@ watch(
       <v-main>
         <router-view class="pa-4" />
         <BaseDialog>
-          <!-- <AssignManager
-            v-if="dialogStore.dialogState.type === 'assign-to-manager'"
-          />
-          <ConvertEmployeeType
-            v-if="dialogStore.dialogState.type === 'convert-employee-type'"
-          />
-          <RehireEmployee
-            v-if="dialogStore.dialogState.type === 'rehire-employee'"
-          /> -->
           <component :is="currentDialog" v-if="currentDialog" />
         </BaseDialog>
       </v-main>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -3,6 +3,8 @@ import { ref } from "vue";
 // Components
 import BaseDialog from "./components/baseDialog/BaseDialog.vue";
 import AssignManager from "./components/baseDialog/dialogContent/AssignManager.vue";
+import ConvertEmployeeType from "./components/baseDialog/dialogContent/ConvertEmployeeType.vue";
+import RehireEmployee from "./components/baseDialog/dialogContent/RehireEmployee.vue";
 import { useDialogStore } from "./stores/dialog";
 
 const rail = ref(false);
@@ -72,6 +74,12 @@ const dialogStore = useDialogStore();
         <BaseDialog>
           <AssignManager
             v-if="dialogStore.dialogState.type === 'assign-to-manager'"
+          />
+          <ConvertEmployeeType
+            v-if="dialogStore.dialogState.type === 'convert-employee-type'"
+          />
+          <RehireEmployee
+            v-if="dialogStore.dialogState.type === 'rehire-employee'"
           />
         </BaseDialog>
       </v-main>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,16 +1,37 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, computed, watch } from "vue";
 // Components
 import BaseDialog from "./components/baseDialog/BaseDialog.vue";
-import AssignManager from "./components/baseDialog/dialogContent/AssignManager.vue";
-import ConvertEmployeeType from "./components/baseDialog/dialogContent/ConvertEmployeeType.vue";
-import RehireEmployee from "./components/baseDialog/dialogContent/RehireEmployee.vue";
+// import AssignManager from "./components/baseDialog/dialogContent/AssignManager.vue";
+// import ConvertEmployeeType from "./components/baseDialog/dialogContent/ConvertEmployeeType.vue";
+// import RehireEmployee from "./components/baseDialog/dialogContent/RehireEmployee.vue";
+import { dialogRegistry, dialogMeta } from "./components/baseDialog/registry";
 import { useDialogStore } from "./stores/dialog";
 
 const rail = ref(false);
 const drawer = ref(true);
 const open = ref<string[]>([]);
 const dialogStore = useDialogStore();
+
+const currentDialog = computed(() => {
+  const t = dialogStore.dialogState.type as keyof typeof dialogRegistry | null;
+  return t ? dialogRegistry[t] : null;
+});
+
+watch(
+  () => dialogStore.dialogState.type,
+  (t) => {
+    if (t && dialogMeta[t as keyof typeof dialogMeta]) {
+      const meta = dialogMeta[t as keyof typeof dialogMeta];
+      dialogStore.setDialog({
+        ...dialogStore.dialogState,
+        ...meta,
+        show: true,
+        type: t,
+      });
+    }
+  }
+);
 </script>
 
 <template>
@@ -72,7 +93,7 @@ const dialogStore = useDialogStore();
       <v-main>
         <router-view class="pa-4" />
         <BaseDialog>
-          <AssignManager
+          <!-- <AssignManager
             v-if="dialogStore.dialogState.type === 'assign-to-manager'"
           />
           <ConvertEmployeeType
@@ -80,7 +101,8 @@ const dialogStore = useDialogStore();
           />
           <RehireEmployee
             v-if="dialogStore.dialogState.type === 'rehire-employee'"
-          />
+          /> -->
+          <component :is="currentDialog" v-if="currentDialog" />
         </BaseDialog>
       </v-main>
     </v-layout>

--- a/client/src/components/BulkActionsToolbar.vue
+++ b/client/src/components/BulkActionsToolbar.vue
@@ -22,10 +22,15 @@
         variant="text"
         @click="handleActionClick(action)"
         class="mr-2"
-        :disabled="selectedItems.length === 0"
+        :disabled="
+          !(action.isEnabled?.(selectedItems) ?? selectedItems.length > 0)
+        "
       >
         <v-icon :icon="action.icon" class="mr-2" />
         {{ action.text }}
+        <v-tooltip activator="parent" location="top" v-if="action.tooltip">
+          {{ action.tooltip(selectedItems) }}
+        </v-tooltip>
       </v-btn>
       <v-btn
         icon="mdi-close"

--- a/client/src/components/DataTable.vue
+++ b/client/src/components/DataTable.vue
@@ -24,7 +24,7 @@
 
     <!-- Bulk Actions Toolbar -->
     <BulkActionsToolbar
-      v-if="enableActions && enableActions"
+      v-if="enableActions"
       :selected-items="selectedItems"
       :actions="actions"
     />
@@ -111,7 +111,10 @@ const computedHeaders = computed(() => {
 });
 
 const search = ref("");
-const selectedItems = ref<Employee[]>([]);
+const selectedItems = computed<Employee[]>({
+  get: () => appStore.selectedEmployees,
+  set: (val) => appStore.setSelectedEmployees(val),
+});
 
 const trimmedSearch = computed(() => search.value.trim());
 
@@ -123,20 +126,10 @@ const actions = computed(() => {
   return dialogStore.getActions(props.tableActions);
 });
 
-// Watch items change to clear selections
+// Clear selections when underlying items set changes
 watch(
   () => items.value,
-  () => {
-    selectedItems.value = [];
-  }
-);
-
-// Watch selected items from app store
-watch(
-  () => appStore.selectedEmployees,
-  () => {
-    selectedItems.value = appStore.selectedEmployees;
-  }
+  () => appStore.setSelectedEmployees([])
 );
 </script>
 

--- a/client/src/components/baseDialog/BaseDialog.vue
+++ b/client/src/components/baseDialog/BaseDialog.vue
@@ -2,7 +2,7 @@
   <v-dialog
     v-model="dialogStore.dialogState.show"
     scrollable
-    persistent
+    :persistent="dialogStore.dialogState.persistent ?? true"
     :width="dialogWidth"
   >
     <v-card>
@@ -30,6 +30,7 @@ import { useDialogStore } from "../../stores/dialog";
 const dialogStore = useDialogStore();
 
 const dialogWidth = computed(() => {
+  if (dialogStore.dialogState.maxWidth) return dialogStore.dialogState.maxWidth;
   switch (dialogStore.dialogState.size) {
     case "x-small":
       return "24%";

--- a/client/src/components/baseDialog/dialogContent/ConvertEmployeeType.vue
+++ b/client/src/components/baseDialog/dialogContent/ConvertEmployeeType.vue
@@ -1,61 +1,6 @@
 <template>
   <div class="convert-employee-type-form">
-    <!-- Selected Employees Summary -->
-    <v-card variant="outlined" class="mb-4 summary-card dialog-summary">
-      <v-card-title class="text-subtitle-1 section-header py-2">
-        <v-icon class="mr-2" size="small">mdi-account-multiple</v-icon>
-        Selected Employees ({{ selectedEmployees.length }})
-      </v-card-title>
-      <v-card-text class="pa-3">
-        <!-- Empty state -->
-        <div v-if="selectedEmployees.length === 0" class="empty-state">
-          <v-icon size="48" color="grey-lighten-1" class="mb-3">
-            mdi-account-off
-          </v-icon>
-          <p class="text-body-2 text-grey-darken-1 mb-0">
-            No employees selected for employment type conversion.
-          </p>
-          <p class="text-caption text-grey">
-            Please select employees from the table to convert their employment
-            type.
-          </p>
-        </div>
-
-        <!-- Employee list with remove functionality -->
-        <div v-else class="employee-list">
-          <v-chip
-            v-for="employee in selectedEmployees"
-            :key="employee._id"
-            class="ma-1"
-            color="primary"
-            variant="outlined"
-            size="small"
-            closable
-            @click:close="removeEmployee(employee._id)"
-          >
-            <v-icon start icon="mdi-account" />
-            {{ employee.fullName }}
-            <span class="ml-2 text-caption"
-              >({{ employee.employmentType }})</span
-            >
-          </v-chip>
-
-          <!-- Clear all button -->
-          <div class="mt-3" v-if="selectedEmployees.length > 1">
-            <v-btn
-              size="small"
-              variant="text"
-              color="error"
-              @click="clearAllEmployees"
-              class="text-caption"
-            >
-              <v-icon start size="small">mdi-close-circle</v-icon>
-              Clear All
-            </v-btn>
-          </div>
-        </div>
-      </v-card-text>
-    </v-card>
+    <SelectedEmployeesSummary />
 
     <!-- Employment Type Conversion Form -->
     <v-form>
@@ -136,26 +81,14 @@
       </v-card>
 
       <!-- Action Buttons -->
-      <div class="d-flex justify-end mt-4 gap-3">
-        <v-btn
-          color="grey"
-          variant="outlined"
-          @click="dialogStore.closeAndResetDialog()"
-          :disabled="isConverting"
-        >
-          <v-icon class="mr-2" size="small">mdi-close</v-icon>
-          Cancel
-        </v-btn>
-        <v-btn
-          color="primary"
-          :loading="isConverting"
-          :disabled="!selectedEmploymentType || selectedEmployees.length === 0"
-          @click="convertEmploymentType"
-        >
-          <v-icon class="mr-2" size="small">mdi-account-convert</v-icon>
-          Convert Employment Type
-        </v-btn>
-      </div>
+      <DialogActions
+        :loading="isConverting"
+        :disabled="!selectedEmploymentType || selectedEmployees.length === 0"
+        submit-text="Convert Employment Type"
+        submit-icon="mdi-account-convert"
+        :on-cancel="() => dialogStore.closeAndResetDialog()"
+        :on-submit="convertEmploymentType"
+      />
     </v-form>
   </div>
 </template>
@@ -168,9 +101,13 @@ import { z } from "zod";
 import { useDialogStore } from "../../../stores/dialog";
 import { useAppStore } from "../../../stores/app";
 import type { EmploymentType } from "../../../types";
+import SelectedEmployeesSummary from "./SelectedEmployeesSummary.vue";
+import DialogActions from "./DialogActions.vue";
+import { useBulkDialogForm } from "../../../composables/useBulkDialogForm";
 
 const dialogStore = useDialogStore();
 const appStore = useAppStore();
+const { selectedEmployees, today } = useBulkDialogForm();
 
 // Form validation schema
 const convertEmploymentTypeSchema = z.object({
@@ -189,7 +126,7 @@ const { errors, defineField, validate, resetForm } = useForm({
   initialValues: {
     employmentType: "",
     conversionNotes: "",
-    effectiveDate: new Date().toISOString().split("T")[0], // Today's date
+    effectiveDate: today(),
   } as ConvertEmploymentTypeFormData,
 });
 
@@ -201,9 +138,6 @@ const [effectiveDate] = defineField("effectiveDate");
 // State
 const isConverting = ref(false);
 
-// Computed properties
-const selectedEmployees = computed(() => appStore.selectedEmployees);
-
 const employmentTypeOptions = computed(() =>
   appStore.formOptions.employmentTypes.map((type: EmploymentType) => ({
     title: type,
@@ -213,15 +147,7 @@ const employmentTypeOptions = computed(() =>
 );
 
 // Methods
-const removeEmployee = (employeeId: string | undefined) => {
-  if (employeeId) {
-    appStore.removeSelectedEmployee(employeeId);
-  }
-};
-
-const clearAllEmployees = () => {
-  appStore.setSelectedEmployees([]);
-};
+// Selection helpers handled by SelectedEmployeesSummary component
 
 const convertEmploymentType = async () => {
   isConverting.value = true;
@@ -265,8 +191,7 @@ const convertEmploymentType = async () => {
 
 // Initialize form when component mounts
 onMounted(() => {
-  // Set default effective date to today
-  effectiveDate.value = new Date().toISOString().split("T")[0];
+  effectiveDate.value = today();
 });
 </script>
 

--- a/client/src/components/baseDialog/dialogContent/ConvertEmployeeType.vue
+++ b/client/src/components/baseDialog/dialogContent/ConvertEmployeeType.vue
@@ -1,0 +1,275 @@
+<template>
+  <div class="convert-employee-type-form">
+    <!-- Selected Employees Summary -->
+    <v-card variant="outlined" class="mb-4 summary-card dialog-summary">
+      <v-card-title class="text-subtitle-1 section-header py-2">
+        <v-icon class="mr-2" size="small">mdi-account-multiple</v-icon>
+        Selected Employees ({{ selectedEmployees.length }})
+      </v-card-title>
+      <v-card-text class="pa-3">
+        <!-- Empty state -->
+        <div v-if="selectedEmployees.length === 0" class="empty-state">
+          <v-icon size="48" color="grey-lighten-1" class="mb-3">
+            mdi-account-off
+          </v-icon>
+          <p class="text-body-2 text-grey-darken-1 mb-0">
+            No employees selected for employment type conversion.
+          </p>
+          <p class="text-caption text-grey">
+            Please select employees from the table to convert their employment
+            type.
+          </p>
+        </div>
+
+        <!-- Employee list with remove functionality -->
+        <div v-else class="employee-list">
+          <v-chip
+            v-for="employee in selectedEmployees"
+            :key="employee._id"
+            class="ma-1"
+            color="primary"
+            variant="outlined"
+            size="small"
+            closable
+            @click:close="removeEmployee(employee._id)"
+          >
+            <v-icon start icon="mdi-account" />
+            {{ employee.fullName }}
+            <span class="ml-2 text-caption"
+              >({{ employee.employmentType }})</span
+            >
+          </v-chip>
+
+          <!-- Clear all button -->
+          <div class="mt-3" v-if="selectedEmployees.length > 1">
+            <v-btn
+              size="small"
+              variant="text"
+              color="error"
+              @click="clearAllEmployees"
+              class="text-caption"
+            >
+              <v-icon start size="small">mdi-close-circle</v-icon>
+              Clear All
+            </v-btn>
+          </div>
+        </div>
+      </v-card-text>
+    </v-card>
+
+    <!-- Employment Type Conversion Form -->
+    <v-form>
+      <v-card variant="outlined" class="section-card">
+        <v-card-title class="text-subtitle-1 section-header py-2">
+          <v-icon class="mr-2" size="small">mdi-account-convert</v-icon>
+          Employment Type Conversion
+        </v-card-title>
+        <v-card-text class="pa-3">
+          <v-row dense>
+            <v-col cols="12">
+              <v-select
+                v-model="selectedEmploymentType"
+                :items="employmentTypeOptions"
+                label="New Employment Type *"
+                required
+                variant="outlined"
+                density="compact"
+                :error-messages="errors.employmentType"
+                class="form-field"
+                color="primary"
+                item-title="title"
+                item-value="value"
+                clearable
+                :hint="
+                  selectedEmploymentType
+                    ? `Converting to: ${selectedEmploymentType}`
+                    : 'Choose the new employment type for selected employees'
+                "
+                persistent-hint
+              >
+                <template v-slot:item="{ props, item }">
+                  <v-list-item v-bind="props">
+                    <template v-slot:prepend>
+                      <v-avatar size="32" color="primary">
+                        <v-icon icon="mdi-account-convert" />
+                      </v-avatar>
+                    </template>
+                    <v-list-item-title>{{ item.raw.title }}</v-list-item-title>
+                    <v-list-item-subtitle>{{
+                      item.raw.subtitle
+                    }}</v-list-item-subtitle>
+                  </v-list-item>
+                </template>
+              </v-select>
+            </v-col>
+            <v-col cols="12">
+              <v-textarea
+                v-model="conversionNotes"
+                label="Conversion Notes"
+                variant="outlined"
+                rows="3"
+                density="compact"
+                :error-messages="errors.conversionNotes"
+                class="form-field"
+                color="primary"
+                hint="Optional notes about this employment type conversion"
+                persistent-hint
+              />
+            </v-col>
+            <v-col cols="12">
+              <v-text-field
+                v-model="effectiveDate"
+                label="Effective Date *"
+                type="date"
+                required
+                variant="outlined"
+                density="compact"
+                :error-messages="errors.effectiveDate"
+                class="form-field"
+                color="primary"
+                hint="Date when the employment type change becomes effective"
+                persistent-hint
+              />
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+
+      <!-- Action Buttons -->
+      <div class="d-flex justify-end mt-4 gap-3">
+        <v-btn
+          color="grey"
+          variant="outlined"
+          @click="dialogStore.closeAndResetDialog()"
+          :disabled="isConverting"
+        >
+          <v-icon class="mr-2" size="small">mdi-close</v-icon>
+          Cancel
+        </v-btn>
+        <v-btn
+          color="primary"
+          :loading="isConverting"
+          :disabled="!selectedEmploymentType || selectedEmployees.length === 0"
+          @click="convertEmploymentType"
+        >
+          <v-icon class="mr-2" size="small">mdi-account-convert</v-icon>
+          Convert Employment Type
+        </v-btn>
+      </div>
+    </v-form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from "vue";
+import { useForm } from "vee-validate";
+import { toTypedSchema } from "@vee-validate/zod";
+import { z } from "zod";
+import { useDialogStore } from "../../../stores/dialog";
+import { useAppStore } from "../../../stores/app";
+import type { EmploymentType } from "../../../types";
+
+const dialogStore = useDialogStore();
+const appStore = useAppStore();
+
+// Form validation schema
+const convertEmploymentTypeSchema = z.object({
+  employmentType: z.string().min(1, "Please select an employment type"),
+  conversionNotes: z.string().optional(),
+  effectiveDate: z.string().min(1, "Please select an effective date"),
+});
+
+type ConvertEmploymentTypeFormData = z.infer<
+  typeof convertEmploymentTypeSchema
+>;
+
+// VeeValidate form setup
+const { errors, defineField, validate, resetForm } = useForm({
+  validationSchema: toTypedSchema(convertEmploymentTypeSchema),
+  initialValues: {
+    employmentType: "",
+    conversionNotes: "",
+    effectiveDate: new Date().toISOString().split("T")[0], // Today's date
+  } as ConvertEmploymentTypeFormData,
+});
+
+// Define form fields
+const [selectedEmploymentType] = defineField("employmentType");
+const [conversionNotes] = defineField("conversionNotes");
+const [effectiveDate] = defineField("effectiveDate");
+
+// State
+const isConverting = ref(false);
+
+// Computed properties
+const selectedEmployees = computed(() => appStore.selectedEmployees);
+
+const employmentTypeOptions = computed(() =>
+  appStore.formOptions.employmentTypes.map((type: EmploymentType) => ({
+    title: type,
+    value: type,
+    subtitle: `Convert selected employees to ${type}`,
+  }))
+);
+
+// Methods
+const removeEmployee = (employeeId: string | undefined) => {
+  if (employeeId) {
+    appStore.removeSelectedEmployee(employeeId);
+  }
+};
+
+const clearAllEmployees = () => {
+  appStore.setSelectedEmployees([]);
+};
+
+const convertEmploymentType = async () => {
+  isConverting.value = true;
+
+  try {
+    // Check if there are selected employees
+    if (selectedEmployees.value.length === 0) {
+      console.error("No employees selected");
+      isConverting.value = false;
+      return;
+    }
+
+    // Validate the form
+    const { valid } = await validate();
+    if (!valid) {
+      isConverting.value = false;
+      return;
+    }
+
+    // Use the bulk convert method from the store
+    const employeeIds = selectedEmployees.value
+      .map((emp) => emp._id)
+      .filter((id) => id) as string[];
+
+    appStore.bulkConvertEmploymentType(
+      employeeIds,
+      selectedEmploymentType.value as EmploymentType,
+      effectiveDate.value || new Date().toISOString().split("T")[0],
+      conversionNotes.value || ""
+    );
+
+    // Close the dialog and reset form
+    dialogStore.closeAndResetDialog();
+    resetForm();
+  } catch (error) {
+    console.error("Error converting employment type:", error);
+  } finally {
+    isConverting.value = false;
+  }
+};
+
+// Initialize form when component mounts
+onMounted(() => {
+  // Set default effective date to today
+  effectiveDate.value = new Date().toISOString().split("T")[0];
+});
+</script>
+
+<style scoped>
+/* Component-specific styles only - common styles are in global CSS */
+</style>

--- a/client/src/components/baseDialog/dialogContent/DialogActions.vue
+++ b/client/src/components/baseDialog/dialogContent/DialogActions.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="d-flex justify-end mt-4 gap-3">
+    <v-btn
+      color="grey"
+      variant="outlined"
+      :disabled="loading"
+      @click="onCancel"
+    >
+      <v-icon class="mr-2" size="small">mdi-close</v-icon>
+      Cancel
+    </v-btn>
+    <v-btn
+      color="primary"
+      :loading="loading"
+      :disabled="disabled"
+      @click="onSubmit"
+    >
+      <v-icon class="mr-2" size="small" :icon="submitIcon" />
+      {{ submitText }}
+    </v-btn>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  loading: boolean;
+  disabled: boolean;
+  submitText: string;
+  submitIcon: string;
+  onCancel: () => void;
+  onSubmit: () => void;
+}>();
+</script>
+
+<style scoped></style>

--- a/client/src/components/baseDialog/dialogContent/RehireEmployee.vue
+++ b/client/src/components/baseDialog/dialogContent/RehireEmployee.vue
@@ -1,0 +1,435 @@
+<template>
+  <div class="rehire-employee-form">
+    <!-- Selected Employees Summary -->
+    <v-card variant="outlined" class="mb-4 summary-card dialog-summary">
+      <v-card-title class="text-subtitle-1 section-header py-2">
+        <v-icon class="mr-2" size="small">mdi-account-multiple</v-icon>
+        Selected Employees ({{ selectedEmployees.length }})
+      </v-card-title>
+      <v-card-text class="pa-3">
+        <!-- Empty state -->
+        <div v-if="selectedEmployees.length === 0" class="empty-state">
+          <v-icon size="48" color="grey-lighten-1" class="mb-3">
+            mdi-account-off
+          </v-icon>
+          <p class="text-body-2 text-grey-darken-1 mb-0">
+            No employees selected for rehiring.
+          </p>
+          <p class="text-caption text-grey">
+            Please select terminated employees from the table to rehire them.
+          </p>
+        </div>
+
+        <!-- Employee list with remove functionality -->
+        <div v-else class="employee-list">
+          <v-chip
+            v-for="employee in selectedEmployees"
+            :key="employee._id"
+            class="ma-1"
+            color="primary"
+            variant="outlined"
+            size="small"
+            closable
+            @click:close="removeEmployee(employee._id)"
+          >
+            <v-icon start icon="mdi-account" />
+            {{ employee.fullName }}
+            <span class="ml-2 text-caption">({{ employee.department }})</span>
+          </v-chip>
+
+          <!-- Clear all button -->
+          <div class="mt-3" v-if="selectedEmployees.length > 1">
+            <v-btn
+              size="small"
+              variant="text"
+              color="error"
+              @click="clearAllEmployees"
+              class="text-caption"
+            >
+              <v-icon start size="small">mdi-close-circle</v-icon>
+              Clear All
+            </v-btn>
+          </div>
+        </div>
+      </v-card-text>
+    </v-card>
+
+    <!-- Rehire Information Form -->
+    <v-form>
+      <v-card variant="outlined" class="section-card mb-4">
+        <v-card-title class="text-subtitle-1 section-header py-2">
+          <v-icon class="mr-2" size="small">mdi-account-plus</v-icon>
+          Rehire Information
+        </v-card-title>
+        <v-card-text class="pa-3">
+          <v-row dense>
+            <v-col cols="12" md="6">
+              <v-text-field
+                v-model="rehireDate"
+                label="Rehire Date *"
+                type="date"
+                required
+                variant="outlined"
+                density="compact"
+                :error-messages="errors.rehireDate"
+                class="form-field"
+                color="primary"
+                hint="Date when the employee will be rehired"
+                persistent-hint
+              />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-select
+                v-model="newDepartment"
+                :items="departmentOptions"
+                label="Department *"
+                required
+                variant="outlined"
+                density="compact"
+                :error-messages="errors.department"
+                class="form-field"
+                color="primary"
+                hint="Department for the rehired employee"
+                persistent-hint
+              />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-text-field
+                v-model="newPosition"
+                label="Position *"
+                required
+                variant="outlined"
+                density="compact"
+                :error-messages="errors.position"
+                class="form-field"
+                color="primary"
+                hint="Job position for the rehired employee"
+                persistent-hint
+              />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-select
+                v-model="newJobLevel"
+                :items="jobLevelOptions"
+                label="Job Level *"
+                required
+                variant="outlined"
+                density="compact"
+                :error-messages="errors.jobLevel"
+                class="form-field"
+                color="primary"
+                hint="Job level for the rehired employee"
+                persistent-hint
+                item-title="text"
+                item-value="value"
+              />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-text-field
+                v-model="newSalary"
+                label="Salary *"
+                type="number"
+                required
+                variant="outlined"
+                density="compact"
+                :error-messages="errors.salary"
+                class="form-field"
+                color="primary"
+                hint="Annual salary for the rehired employee"
+                persistent-hint
+                prefix="$"
+              />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-select
+                v-model="newEmploymentType"
+                :items="employmentTypeOptions"
+                label="Employment Type *"
+                required
+                variant="outlined"
+                density="compact"
+                :error-messages="errors.employmentType"
+                class="form-field"
+                color="primary"
+                hint="Employment type for the rehired employee"
+                persistent-hint
+                item-title="text"
+                item-value="value"
+              />
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+
+      <!-- Manager Assignment -->
+      <v-card variant="outlined" class="section-card mb-4">
+        <v-card-title class="text-subtitle-1 section-header py-2">
+          <v-icon class="mr-2" size="small">mdi-account-tie</v-icon>
+          Manager Assignment
+        </v-card-title>
+        <v-card-text class="pa-3">
+          <v-row dense>
+            <v-col cols="12">
+              <v-select
+                v-model="selectedManagerId"
+                :items="managerOptions"
+                label="Select Manager"
+                variant="outlined"
+                density="compact"
+                :error-messages="errors.managerId"
+                class="form-field"
+                color="primary"
+                item-title="title"
+                item-value="value"
+                clearable
+                :hint="
+                  selectedManagerId
+                    ? `Manager: ${getSelectedManagerInfo()}`
+                    : 'Choose a manager for the rehired employee (optional)'
+                "
+                persistent-hint
+              >
+                <template v-slot:item="{ props, item }">
+                  <v-list-item v-bind="props">
+                    <template v-slot:prepend>
+                      <v-avatar size="32" color="primary">
+                        <v-icon icon="mdi-account-tie" />
+                      </v-avatar>
+                    </template>
+                    <v-list-item-title>{{ item.raw.title }}</v-list-item-title>
+                    <v-list-item-subtitle>{{
+                      item.raw.subtitle
+                    }}</v-list-item-subtitle>
+                  </v-list-item>
+                </template>
+              </v-select>
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+
+      <!-- Additional Information -->
+      <v-card variant="outlined" class="section-card">
+        <v-card-title class="text-subtitle-1 section-header py-2">
+          <v-icon class="mr-2" size="small">mdi-note-text</v-icon>
+          Additional Information
+        </v-card-title>
+        <v-card-text class="pa-3">
+          <v-row dense>
+            <v-col cols="12">
+              <v-textarea
+                v-model="rehireNotes"
+                label="Rehire Notes"
+                variant="outlined"
+                rows="3"
+                density="compact"
+                :error-messages="errors.rehireNotes"
+                class="form-field"
+                color="primary"
+                hint="Optional notes about the rehiring process"
+                persistent-hint
+              />
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+
+      <!-- Action Buttons -->
+      <div class="d-flex justify-end mt-4 gap-3">
+        <v-btn
+          color="grey"
+          variant="outlined"
+          @click="dialogStore.closeAndResetDialog()"
+          :disabled="isRehiring"
+        >
+          <v-icon class="mr-2" size="small">mdi-close</v-icon>
+          Cancel
+        </v-btn>
+        <v-btn
+          color="primary"
+          :loading="isRehiring"
+          :disabled="!isFormValid || selectedEmployees.length === 0"
+          @click="rehireEmployees"
+        >
+          <v-icon class="mr-2" size="small">mdi-account-plus</v-icon>
+          Rehire Employees
+        </v-btn>
+      </div>
+    </v-form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from "vue";
+import { useForm } from "vee-validate";
+import { toTypedSchema } from "@vee-validate/zod";
+import { z } from "zod";
+import { useDialogStore } from "../../../stores/dialog";
+import { useAppStore } from "../../../stores/app";
+import type { Manager, JobLevel, EmploymentType } from "../../../types";
+
+const dialogStore = useDialogStore();
+const appStore = useAppStore();
+
+// Form validation schema
+const rehireEmployeeSchema = z.object({
+  rehireDate: z.string().min(1, "Please select a rehire date"),
+  department: z.string().min(1, "Please select a department"),
+  position: z.string().min(1, "Please enter a position"),
+  jobLevel: z.string().min(1, "Please select a job level"),
+  salary: z.number().min(1, "Please enter a valid salary"),
+  employmentType: z.string().min(1, "Please select an employment type"),
+  managerId: z.string().optional(),
+  rehireNotes: z.string().optional(),
+});
+
+type RehireEmployeeFormData = z.infer<typeof rehireEmployeeSchema>;
+
+// VeeValidate form setup
+const { errors, defineField, validate, resetForm } = useForm({
+  validationSchema: toTypedSchema(rehireEmployeeSchema),
+  initialValues: {
+    rehireDate: new Date().toISOString().split("T")[0],
+    department: "",
+    position: "",
+    jobLevel: "",
+    salary: 0,
+    employmentType: "",
+    managerId: "",
+    rehireNotes: "",
+  } as RehireEmployeeFormData,
+});
+
+// Define form fields
+const [rehireDate] = defineField("rehireDate");
+const [newDepartment] = defineField("department");
+const [newPosition] = defineField("position");
+const [newJobLevel] = defineField("jobLevel");
+const [newSalary] = defineField("salary");
+const [newEmploymentType] = defineField("employmentType");
+const [selectedManagerId] = defineField("managerId");
+const [rehireNotes] = defineField("rehireNotes");
+
+// State
+const isRehiring = ref(false);
+
+// Computed properties
+const selectedEmployees = computed(() => appStore.selectedEmployees);
+
+const departmentOptions = computed(() =>
+  appStore.departments.map((dept) => dept.name)
+);
+
+const jobLevelOptions = computed(() =>
+  appStore.formOptions.jobLevels.map((level) => ({
+    text: level,
+    value: level,
+  }))
+);
+
+const employmentTypeOptions = computed(() =>
+  appStore.formOptions.employmentTypes.map((type) => ({
+    text: type,
+    value: type,
+  }))
+);
+
+const managerOptions = computed(() =>
+  appStore.managers.map((manager: Manager) => ({
+    title: manager.name,
+    value: manager.id,
+    subtitle: `${manager.department} - ${manager.email}`,
+    manager: manager,
+  }))
+);
+
+const isFormValid = computed(() => {
+  return (
+    rehireDate.value &&
+    newDepartment.value &&
+    newPosition.value &&
+    newJobLevel.value &&
+    newSalary.value !== undefined &&
+    newSalary.value > 0 &&
+    newEmploymentType.value
+  );
+});
+
+// Methods
+const getSelectedManagerInfo = () => {
+  const manager = appStore.managers.find(
+    (m: Manager) => m.id === selectedManagerId.value
+  );
+  return manager ? `${manager.name} (${manager.department})` : "";
+};
+
+const removeEmployee = (employeeId: string | undefined) => {
+  if (employeeId) {
+    appStore.removeSelectedEmployee(employeeId);
+  }
+};
+
+const clearAllEmployees = () => {
+  appStore.setSelectedEmployees([]);
+};
+
+const rehireEmployees = async () => {
+  isRehiring.value = true;
+
+  try {
+    // Check if there are selected employees
+    if (selectedEmployees.value.length === 0) {
+      console.error("No employees selected");
+      isRehiring.value = false;
+      return;
+    }
+
+    // Validate the form
+    const { valid } = await validate();
+    if (!valid) {
+      isRehiring.value = false;
+      return;
+    }
+
+    // Get the selected manager if one is selected
+    const selectedManager = selectedManagerId.value
+      ? appStore.managers.find((m: Manager) => m.id === selectedManagerId.value)
+      : null;
+
+    // Use the bulk rehire method from the store
+    const employeeIds = selectedEmployees.value
+      .map((emp) => emp._id)
+      .filter((id) => id) as string[];
+
+    appStore.bulkRehireEmployees(employeeIds, {
+      rehireDate: rehireDate.value || new Date().toISOString().split("T")[0],
+      department: newDepartment.value || "",
+      position: newPosition.value || "",
+      jobLevel: newJobLevel.value as JobLevel,
+      salary: Number(newSalary.value || 0),
+      employmentType: newEmploymentType.value as EmploymentType,
+      managerId: selectedManager?.id || "",
+      managerName: selectedManager?.name || "",
+      notes: rehireNotes.value || "",
+    });
+
+    // Close the dialog and reset form
+    dialogStore.closeAndResetDialog();
+    resetForm();
+  } catch (error) {
+    console.error("Error rehiring employees:", error);
+  } finally {
+    isRehiring.value = false;
+  }
+};
+
+// Initialize form when component mounts
+onMounted(() => {
+  // Set default rehire date to today
+  rehireDate.value = new Date().toISOString().split("T")[0];
+});
+</script>
+
+<style scoped>
+/* Component-specific styles only - common styles are in global CSS */
+</style>

--- a/client/src/components/baseDialog/dialogContent/SelectedEmployeesSummary.vue
+++ b/client/src/components/baseDialog/dialogContent/SelectedEmployeesSummary.vue
@@ -1,0 +1,70 @@
+<template>
+  <v-card variant="outlined" class="mb-4 summary-card dialog-summary">
+    <v-card-title class="text-subtitle-1 section-header py-2">
+      <v-icon class="mr-2" size="small">mdi-account-multiple</v-icon>
+      Selected Employees ({{ selectedEmployees.length }})
+    </v-card-title>
+    <v-card-text class="pa-3">
+      <div v-if="selectedEmployees.length === 0" class="empty-state">
+        <v-icon size="48" color="grey-lighten-1" class="mb-3">
+          mdi-account-off
+        </v-icon>
+        <p class="text-body-2 text-grey-darken-1 mb-0">
+          No employees selected.
+        </p>
+        <p class="text-caption text-grey">
+          Please select employees from the table first.
+        </p>
+      </div>
+
+      <div v-else class="employee-list">
+        <v-chip
+          v-for="employee in selectedEmployees"
+          :key="employee._id"
+          class="ma-1"
+          color="primary"
+          variant="outlined"
+          size="small"
+          closable
+          @click:close="removeEmployee(employee._id)"
+        >
+          <v-icon start icon="mdi-account" />
+          {{ employee.fullName }}
+          <span class="ml-2 text-caption">({{ employee.department }})</span>
+        </v-chip>
+
+        <div class="mt-3" v-if="selectedEmployees.length > 1">
+          <v-btn
+            size="small"
+            variant="text"
+            color="error"
+            @click="clearAllEmployees"
+            class="text-caption"
+          >
+            <v-icon start size="small">mdi-close-circle</v-icon>
+            Clear All
+          </v-btn>
+        </div>
+      </div>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useAppStore } from "../../../stores/app";
+import type { Employee } from "../../../types";
+
+const appStore = useAppStore();
+const selectedEmployees = computed<Employee[]>(
+  () => appStore.selectedEmployees
+);
+
+const removeEmployee = (employeeId: string | undefined) => {
+  if (employeeId) appStore.removeSelectedEmployee(employeeId);
+};
+
+const clearAllEmployees = () => appStore.setSelectedEmployees([]);
+</script>
+
+<style scoped></style>

--- a/client/src/components/baseDialog/registry.ts
+++ b/client/src/components/baseDialog/registry.ts
@@ -1,0 +1,19 @@
+import { defineAsyncComponent } from "vue";
+
+export const dialogRegistry = {
+  "assign-to-manager": defineAsyncComponent(
+    () => import("./dialogContent/AssignManager.vue")
+  ),
+  "convert-employee-type": defineAsyncComponent(
+    () => import("./dialogContent/ConvertEmployeeType.vue")
+  ),
+  "rehire-employee": defineAsyncComponent(
+    () => import("./dialogContent/RehireEmployee.vue")
+  ),
+} as const;
+
+export const dialogMeta = {
+  "assign-to-manager": { header: "Assign Manager", size: "medium" },
+  "convert-employee-type": { header: "Convert Employee Type", size: "medium" },
+  "rehire-employee": { header: "Rehire Employee", size: "medium" },
+} as const;

--- a/client/src/composables/useBulkDialogForm.ts
+++ b/client/src/composables/useBulkDialogForm.ts
@@ -1,0 +1,41 @@
+import { computed, ref } from "vue";
+import { useAppStore } from "../stores/app";
+import { useDialogStore } from "../stores/dialog";
+import type { Employee } from "../types";
+
+export function useBulkDialogForm() {
+  const appStore = useAppStore();
+  const dialogStore = useDialogStore();
+
+  const isBusy = ref(false);
+
+  const selectedEmployees = computed<Employee[]>(
+    () => appStore.selectedEmployees
+  );
+
+  const employeeIds = computed<string[]>(() =>
+    selectedEmployees.value
+      .map((emp) => emp._id)
+      .filter((id): id is string => Boolean(id))
+  );
+
+  const today = () => new Date().toISOString().split("T")[0];
+
+  const removeEmployee = (employeeId: string | undefined) => {
+    if (employeeId) appStore.removeSelectedEmployee(employeeId);
+  };
+
+  const clearAllEmployees = () => appStore.setSelectedEmployees([]);
+
+  const closeDialog = () => dialogStore.closeAndResetDialog();
+
+  return {
+    isBusy,
+    selectedEmployees,
+    employeeIds,
+    today,
+    removeEmployee,
+    clearAllEmployees,
+    closeDialog,
+  };
+}

--- a/client/src/stores/app.ts
+++ b/client/src/stores/app.ts
@@ -2323,6 +2323,118 @@ export const useAppStore = defineStore("app", () => {
     refreshKey.value += 1;
   };
 
+  const bulkConvertEmploymentType = (
+    employeeIds: string[],
+    newEmploymentType: EmploymentType,
+    effectiveDate: string,
+    notes?: string
+  ): void => {
+    console.log(
+      `Bulk converting employment type to ${newEmploymentType} for employees:`,
+      employeeIds
+    );
+
+    employeeIds.forEach((empId) => {
+      const employee = employees.value.find((emp) => emp._id === empId);
+      if (employee) {
+        console.log(
+          `Converting employee ${employee.fullName} from ${employee.employmentType} to ${newEmploymentType}`
+        );
+        const updatedEmployee: Employee = {
+          ...employee,
+          employmentType: newEmploymentType,
+          hrAssignment: {
+            ...employee.hrAssignment,
+            reviewComments: notes
+              ? `Employment type converted to ${newEmploymentType} on ${effectiveDate}. ${notes}`
+              : `Employment type converted to ${newEmploymentType} on ${effectiveDate}`,
+          },
+          updatedBy: "hr_admin",
+          updatedOn: new Date().toISOString().split("T")[0],
+          updatedAt: new Date().toISOString(),
+          lastProfileUpdate: new Date().toISOString().split("T")[0],
+        };
+        updateEmployee(updatedEmployee);
+        console.log(
+          `Employee ${employee.fullName} employment type updated to: ${updatedEmployee.employmentType}`
+        );
+      } else {
+        console.error(`Employee with ID ${empId} not found`);
+      }
+    });
+    selectedEmployees.value = [];
+    refreshKey.value += 1;
+  };
+
+  const bulkRehireEmployees = (
+    employeeIds: string[],
+    rehireData: {
+      rehireDate: string;
+      department: string;
+      position: string;
+      jobLevel: JobLevel;
+      salary: number;
+      employmentType: EmploymentType;
+      managerId: string;
+      managerName: string;
+      notes: string;
+    }
+  ): void => {
+    console.log(
+      `Bulk rehiring employees:`,
+      employeeIds,
+      "with data:",
+      rehireData
+    );
+
+    employeeIds.forEach((empId) => {
+      const employee = employees.value.find((emp) => emp._id === empId);
+      if (employee) {
+        console.log(
+          `Rehiring employee ${employee.fullName} to ${rehireData.department} as ${rehireData.position}`
+        );
+        const updatedEmployee: Employee = {
+          ...employee,
+          status: "Active",
+          department: rehireData.department,
+          position: rehireData.position,
+          jobLevel: rehireData.jobLevel,
+          salary: rehireData.salary,
+          employmentType: rehireData.employmentType,
+          managerId: rehireData.managerId || undefined,
+          managerName: rehireData.managerName || undefined,
+          hireDate: rehireData.rehireDate, // Update hire date to rehire date
+          terminationDate: undefined, // Clear termination date
+          hrAssignment: {
+            ...employee.hrAssignment,
+            managerEmail: rehireData.managerId
+              ? managers.value.find((m) => m.id === rehireData.managerId)
+                  ?.email || ""
+              : "",
+            managerAssignDate: rehireData.managerId
+              ? rehireData.rehireDate
+              : undefined,
+            reviewComments: rehireData.notes
+              ? `Employee rehired on ${rehireData.rehireDate}. ${rehireData.notes}`
+              : `Employee rehired on ${rehireData.rehireDate}`,
+          },
+          updatedBy: "hr_admin",
+          updatedOn: new Date().toISOString().split("T")[0],
+          updatedAt: new Date().toISOString(),
+          lastProfileUpdate: new Date().toISOString().split("T")[0],
+        };
+        updateEmployee(updatedEmployee);
+        console.log(
+          `Employee ${employee.fullName} rehired successfully with status: ${updatedEmployee.status}`
+        );
+      } else {
+        console.error(`Employee with ID ${empId} not found`);
+      }
+    });
+    selectedEmployees.value = [];
+    refreshKey.value += 1;
+  };
+
   // Performance Review Methods
   const getPerformanceReviews = async (): Promise<Employee[]> => {
     return employees.value.filter(
@@ -2516,6 +2628,8 @@ export const useAppStore = defineStore("app", () => {
     addEmployee,
     updateEmployee,
     bulkAssignManager,
+    bulkConvertEmploymentType,
+    bulkRehireEmployees,
     // Performance Review Methods
     getPerformanceReviews,
     getOverdueReviews,

--- a/client/src/stores/dialog.ts
+++ b/client/src/stores/dialog.ts
@@ -36,6 +36,14 @@ export const useDialogStore = defineStore("dialog", () => {
         });
       },
       type: "assign-to-manager",
+      isEnabled: (selected) =>
+        selected.length > 0 && selected.every((e) => !e.managerId),
+      tooltip: (selected) =>
+        selected.length === 0
+          ? "Select at least one employee"
+          : selected.some((e) => e.managerId)
+          ? "All selected must be unassigned"
+          : undefined,
     },
     {
       text: "Convert Employee Type",
@@ -49,10 +57,13 @@ export const useDialogStore = defineStore("dialog", () => {
         });
       },
       type: "convert-employee-type",
+      isEnabled: (selected) => selected.length > 0,
+      tooltip: (selected) =>
+        selected.length === 0 ? "Select employees to convert" : undefined,
     },
     {
       text: "Rehire Employee",
-      icon: "mdi-account-plus",
+      icon: "mdi-briefcase-arrow-up-down",
       action: () => {
         setDialog({
           show: true,
@@ -62,6 +73,14 @@ export const useDialogStore = defineStore("dialog", () => {
         });
       },
       type: "rehire-employee",
+      isEnabled: (selected) =>
+        selected.length > 0 && selected.every((e) => e.status === "Terminated"),
+      tooltip: (selected) =>
+        selected.length === 0
+          ? "Select terminated employees"
+          : selected.some((e) => e.status !== "Terminated")
+          ? "Only terminated employees can be rehired"
+          : undefined,
     },
   ]);
 

--- a/client/src/stores/dialog.ts
+++ b/client/src/stores/dialog.ts
@@ -37,6 +37,32 @@ export const useDialogStore = defineStore("dialog", () => {
       },
       type: "assign-to-manager",
     },
+    {
+      text: "Convert Employee Type",
+      icon: "mdi-account-convert",
+      action: () => {
+        setDialog({
+          show: true,
+          header: "Convert Employee Type",
+          size: "medium",
+          type: "convert-employee-type",
+        });
+      },
+      type: "convert-employee-type",
+    },
+    {
+      text: "Rehire Employee",
+      icon: "mdi-account-plus",
+      action: () => {
+        setDialog({
+          show: true,
+          header: "Rehire Employee",
+          size: "medium",
+          type: "rehire-employee",
+        });
+      },
+      type: "rehire-employee",
+    },
   ]);
 
   const getActions = (actionList: ActionType[]) => {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -285,6 +285,8 @@ export interface DialogState {
   header: string;
   size: "x-small" | "small" | "medium" | "large";
   type: string | null;
+  persistent?: boolean;
+  maxWidth?: number | string;
 }
 
 export interface Action {
@@ -292,6 +294,8 @@ export interface Action {
   icon: string;
   action: () => void;
   type: ActionType;
+  isEnabled?: (selected: Employee[]) => boolean;
+  tooltip?: (selected: Employee[]) => string | undefined;
 }
 
 export type ActionType =

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -294,4 +294,7 @@ export interface Action {
   type: ActionType;
 }
 
-export type ActionType = "assign-to-manager";
+export type ActionType =
+  | "assign-to-manager"
+  | "convert-employee-type"
+  | "rehire-employee";

--- a/client/src/views/TableWrapper.vue
+++ b/client/src/views/TableWrapper.vue
@@ -80,6 +80,7 @@ const loadData = async () => {
         enableOpenRecord.value = true;
         enableSelect.value = true;
         items.value = await appStore.getContractEmployees();
+        tableActions.value = ["convert-employee-type"];
         break;
       case "Updated Profiles":
         title.value = "Updated Profiles";
@@ -100,6 +101,7 @@ const loadData = async () => {
         enableOpenRecord.value = true;
         enableSelect.value = true;
         items.value = await appStore.getFormerEmployees();
+        tableActions.value = ["rehire-employee"];
         break;
       default:
         resetData();


### PR DESCRIPTION
- implemented the dynamic dialog registry and simplified App.vue to render dialog content via <component :is="currentDialog" /> driven by dialogRegistry and dialogMeta. The header/size now auto-apply when a type is set.
- I centralized selection: DataTable now two-way binds selection directly to appStore.selectedEmployees and removed redundant watchers; the toolbar reads selection as props.
- I added action guards and tooltips: types.Action includes isEnabled and tooltip. dialogStore actions enforce rules (e.g., rehire only for terminated employees) and show helpful tooltips.
- I created shared dialog UI: SelectedEmployeesSummary.vue and DialogActions.vue, and refactored the three dialog content components to use them.
- I added useBulkDialogForm composable for shared dialog logic and adopted it in the dialogs (date defaults, selection helpers).
- I refactored TableWrapper.vue to a concise route config map for titles, toggles, actions, and data fetchers.
- I enhanced DialogState and BaseDialog.vue to support persistent and maxWidth overrides.