### PR TITLE
Release - Major UI update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 
 - ⚡ **Fast & Responsive** - Optimized Vue 3 with Composition API
 - 🛡️ **Security First** - Protected routes, token expiration, auto-logout
-- 📱 **Mobile Friendly** - Fully responsive design with Vuetify
+- 🖥️ **Desktop & Tablet Optimized** - Responsive layouts tuned for desktop and tablet, with a collapsible sidebar
 - 🔄 **Real-time Updates** - Reactive state management with Pinia
-- 🎨 **Modern UI** - Beautiful Material Design interface
+- 🎨 **Enterprise Design System** - Custom indigo & gold console UI on Vuetify, with a dark sidebar and Plus Jakarta Sans typography
 - ☁️ **Cloud Ready** - Designed for AWS deployment with horizontal scaling
 
 ---
@@ -57,7 +57,7 @@
 - **MongoDB** - Flexible NoSQL database
 - **Motor** - Async MongoDB driver
 - **Pydantic** - Data validation
-- **PyJWT** - JSON Web Token implementation
+- **python-jose** - JSON Web Token (JOSE) implementation
 - **Passlib** - Password hashing with bcrypt
 
 ### DevOps & Deployment
@@ -138,7 +138,7 @@
 - Dynamic tree traversal
 - Visual relationship indicators
 - Interactive node expansion/collapse
-- Responsive layout for mobile devices
+- Responsive layout for desktop and tablet
 
 ### 3. Real-Time Analytics
 

--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,500&display=swap"
+      rel="stylesheet"
+    />
     <title>Employee Management System</title>
   </head>
   <body>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from "vue";
-import { useRouter } from "vue-router";
+import { useRouter, useRoute } from "vue-router";
+import { useDisplay } from "vuetify";
 import BaseDialog from "./components/baseDialog/BaseDialog.vue";
 import { dialogRegistry, dialogMeta } from "./components/baseDialog/registry";
 import { useDialogStore } from "./stores/dialog";
@@ -9,10 +10,90 @@ import { useAppStore } from "./stores/app";
 import { useAuthStore } from "./stores/auth";
 
 const router = useRouter();
+const route = useRoute();
 const rail = ref(false);
 const drawer = ref(true);
-const open = ref<string[]>([]);
 const initialLoading = ref(true);
+
+// Auto-collapse the sidebar to its icon rail below desktop (tablet/small laptop),
+// keep it expanded on desktop. The toolbar button still toggles manually.
+const { lgAndUp } = useDisplay();
+watch(
+  lgAndUp,
+  (isDesktop) => {
+    rail.value = !isDesktop;
+  },
+  { immediate: true }
+);
+
+// Grouped sidebar navigation (enterprise console structure)
+const navGroups = [
+  {
+    label: "Overview",
+    items: [
+      { title: "Dashboard", icon: "mdi-view-dashboard-outline", to: "/" },
+      { title: "Analytics", icon: "mdi-chart-box-outline", to: "/analytics" },
+      {
+        title: "Performance Reviews",
+        icon: "mdi-chart-line",
+        to: "/performance-reviews",
+      },
+    ],
+  },
+  {
+    label: "People",
+    items: [
+      { title: "Search Employees", icon: "mdi-magnify", to: "/search-employees" },
+      { title: "Add Employee", icon: "mdi-account-plus-outline", to: "/employee/new" },
+      { title: "Organization Chart", icon: "mdi-sitemap-outline", to: "/org-chart" },
+    ],
+  },
+  {
+    label: "Segments",
+    items: [
+      { title: "By Manager", icon: "mdi-account-tie-outline", to: "/by-manager" },
+      { title: "By Department", icon: "mdi-domain", to: "/by-department" },
+      { title: "By Status", icon: "mdi-account-switch-outline", to: "/by-status" },
+      {
+        title: "Contract Employees",
+        icon: "mdi-file-document-outline",
+        to: "/contract-employees",
+      },
+      {
+        title: "Former Employees",
+        icon: "mdi-account-minus-outline",
+        to: "/former-employees",
+      },
+    ],
+  },
+  {
+    label: "Pipeline",
+    items: [
+      {
+        title: "Unassigned Hires",
+        icon: "mdi-account-question-outline",
+        to: "/unassigned-hires",
+      },
+      { title: "Recent Hires", icon: "mdi-clock-outline", to: "/recent-hires" },
+      {
+        title: "Updated Profiles",
+        icon: "mdi-account-edit-outline",
+        to: "/updated-profiles",
+      },
+    ],
+  },
+];
+
+// Current page title for the top bar
+const pageTitle = computed(() => (route.name ? String(route.name) : "Dashboard"));
+
+// Initials for the user avatar
+const userInitials = computed(() => {
+  const name = authStore.user?.full_name?.trim();
+  if (!name) return "?";
+  const parts = name.split(/\s+/);
+  return (parts[0][0] + (parts[1]?.[0] ?? "")).toUpperCase();
+});
 
 const dialogStore = useDialogStore();
 const notificationStore = useNotificationStore();
@@ -107,76 +188,84 @@ watch(
 <template>
   <v-app>
     <v-layout>
-      <v-app-bar color="primary" flat>
-        <v-app-bar-nav-icon
-          v-if="authStore.isAuthenticated"
-          @click.stop="rail = !rail"
-        />
-        <v-app-bar-title>
-          <router-link to="/" class="text-white text-decoration-none">
-            Employee Management System
+      <v-navigation-drawer
+        v-if="authStore.isAuthenticated"
+        :rail="rail"
+        v-model="drawer"
+        permanent
+        width="264"
+        class="app-sidebar"
+      >
+        <!-- Brand header -->
+        <div class="sidebar-brand" :class="{ 'sidebar-brand--rail': rail }">
+          <router-link to="/" class="brand-link">
+            <div class="brand-tile">
+              <v-icon size="20" color="#EAB308">mdi-account-group</v-icon>
+            </div>
+            <div v-if="!rail" class="brand-text">
+              <span class="brand-name">EMS</span>
+              <span class="brand-sub">Employee Console</span>
+            </div>
           </router-link>
+        </div>
+
+        <v-divider class="sidebar-divider" />
+
+        <!-- Grouped navigation -->
+        <div class="sidebar-nav">
+          <template v-for="group in navGroups" :key="group.label">
+            <div v-if="!rail" class="nav-group-label">{{ group.label }}</div>
+            <v-list
+              density="compact"
+              nav
+              color="primary"
+              class="nav-list"
+              :class="{ 'nav-list--rail': rail }"
+            >
+              <v-list-item
+                v-for="item in group.items"
+                :key="item.to"
+                :to="item.to"
+                :prepend-icon="item.icon"
+                :title="item.title"
+                class="nav-item"
+                exact
+              />
+            </v-list>
+          </template>
+        </div>
+      </v-navigation-drawer>
+
+      <v-app-bar
+        v-if="authStore.isAuthenticated"
+        flat
+        class="app-topbar"
+        color="white"
+        height="64"
+      >
+        <v-app-bar-nav-icon icon="mdi-menu" @click.stop="rail = !rail" />
+        <v-app-bar-title class="topbar-title">
+          {{ pageTitle }}
         </v-app-bar-title>
 
         <v-spacer></v-spacer>
 
         <template v-if="authStore.isAuthenticated && authStore.user">
-          <v-chip class="mr-2" variant="flat" color="white">
-            <v-icon class="mr-2" color="primary">mdi-account-circle</v-icon>
-            {{ authStore.user.full_name }}
-          </v-chip>
-          <v-btn icon="mdi-logout" @click="handleLogout" title="Logout"></v-btn>
+          <div class="user-chip">
+            <v-avatar size="32" color="primary" class="user-avatar">
+              <span class="user-initials">{{ userInitials }}</span>
+            </v-avatar>
+            <span class="user-name">{{ authStore.user.full_name }}</span>
+          </div>
+          <v-btn
+            icon="mdi-logout-variant"
+            variant="text"
+            class="ml-1"
+            @click="handleLogout"
+            title="Logout"
+          ></v-btn>
         </template>
       </v-app-bar>
-      <v-navigation-drawer
-        v-if="authStore.isAuthenticated"
-        expand-on-hover
-        :rail="rail"
-        v-model="drawer"
-        permanent
-      >
-        <v-list density="compact" v-model:opened="open" color="primary">
-          <v-list-item prepend-icon="mdi-plus" to="/employee/new">
-            <v-list-item-title>Add New Employee</v-list-item-title>
-          </v-list-item>
-          <v-list-item prepend-icon="mdi-magnify" to="/search-employees">
-            <v-list-item-title>Search Employees</v-list-item-title>
-          </v-list-item>
-          <v-list-item prepend-icon="mdi-account-plus" to="/unassigned-hires">
-            <v-list-item-title>Unassigned Hires</v-list-item-title>
-          </v-list-item>
-          <v-list-item prepend-icon="mdi-clock-outline" to="/recent-hires">
-            <v-list-item-title>Recent Hires</v-list-item-title>
-          </v-list-item>
-          <v-list-item prepend-icon="mdi-account-edit" to="/updated-profiles">
-            <v-list-item-title>Updated Profiles</v-list-item-title>
-          </v-list-item>
-          <v-list-item prepend-icon="mdi-account-tie" to="/by-manager">
-            <v-list-item-title>By Manager</v-list-item-title>
-          </v-list-item>
-          <v-list-item prepend-icon="mdi-domain" to="/by-department">
-            <v-list-item-title>By Department</v-list-item-title>
-          </v-list-item>
-          <v-list-item prepend-icon="mdi-account-switch" to="/by-status">
-            <v-list-item-title>By Status</v-list-item-title>
-          </v-list-item>
-          <v-list-item prepend-icon="mdi-handshake" to="/contract-employees">
-            <v-list-item-title>Contract Employees</v-list-item-title>
-          </v-list-item>
-          <v-list-item prepend-icon="mdi-account-minus" to="/former-employees">
-            <v-list-item-title>Former Employees</v-list-item-title>
-          </v-list-item>
-          <v-list-item prepend-icon="mdi-chart-line" to="/performance-reviews">
-            <v-list-item-title>Performance Reviews</v-list-item-title>
-          </v-list-item>
-          <v-list-item prepend-icon="mdi-chart-box" to="/analytics">
-            <v-list-item-title>Analytics</v-list-item-title>
-          </v-list-item>
-          <v-list-item prepend-icon="mdi-sitemap" to="/org-chart">
-            <v-list-item-title>Organization Chart</v-list-item-title>
-          </v-list-item>
-        </v-list>
-      </v-navigation-drawer>
       <v-main>
         <!-- Global loading overlay -->
         <v-overlay
@@ -218,4 +307,169 @@ watch(
   </v-app>
 </template>
 
-<style scoped></style>
+<style scoped>
+/* ===== Sidebar (midnight indigo) ===== */
+.app-sidebar {
+  background: var(--color-sidebar) !important;
+  border-right: none !important;
+  color: #e8e8f5;
+}
+
+/* Brand header */
+.sidebar-brand {
+  padding: 20px 16px 16px;
+}
+.sidebar-brand--rail {
+  padding: 20px 0 16px;
+  display: flex;
+  justify-content: center;
+}
+.brand-link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  text-decoration: none;
+}
+.brand-tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
+  background: rgba(129, 140, 248, 0.18);
+  border: 1px solid rgba(129, 140, 248, 0.3);
+  flex-shrink: 0;
+}
+.brand-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+.brand-name {
+  font-size: 1.125rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: #ffffff;
+}
+.brand-sub {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.4px;
+  color: #a5a3d4;
+}
+
+.sidebar-divider {
+  border-color: rgba(255, 255, 255, 0.08) !important;
+}
+
+/* Navigation */
+.sidebar-nav {
+  padding: 8px 0 24px;
+  overflow-y: auto;
+}
+.nav-group-label {
+  padding: 14px 20px 6px;
+  font-size: 0.625rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.9px;
+  color: #7c7aae;
+}
+.nav-list {
+  background: transparent !important;
+  padding: 0 10px;
+}
+.nav-list--rail {
+  padding: 0 8px;
+}
+
+/* List item text/icons → light on indigo */
+.app-sidebar :deep(.v-list-item__content),
+.app-sidebar :deep(.v-list-item-title) {
+  color: #c7c6e8;
+  font-size: 0.84rem;
+  font-weight: 600;
+}
+.app-sidebar :deep(.v-list-item__prepend > .v-icon) {
+  color: #9a98ce;
+  opacity: 1;
+  margin-inline-end: 12px;
+}
+.app-sidebar :deep(.v-list-item) {
+  border-radius: 8px;
+  min-height: 40px;
+  margin-bottom: 2px;
+}
+
+/* Hover */
+.app-sidebar :deep(.v-list-item:hover) {
+  background: rgba(255, 255, 255, 0.06);
+}
+.app-sidebar :deep(.v-list-item:hover .v-list-item-title) {
+  color: #ffffff;
+}
+.app-sidebar :deep(.v-list-item:hover .v-icon) {
+  color: #c7c6e8;
+}
+
+/* Active — soft violet text + left accent + tinted bg */
+.app-sidebar :deep(.v-list-item--active) {
+  background: rgba(129, 140, 248, 0.16);
+}
+.app-sidebar :deep(.v-list-item--active)::before {
+  opacity: 0;
+}
+.app-sidebar :deep(.v-list-item--active .v-list-item-title) {
+  color: #ffffff;
+}
+.app-sidebar :deep(.v-list-item--active .v-icon) {
+  color: #818cf8;
+  opacity: 1;
+}
+.app-sidebar :deep(.v-list-item--active)::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 8px;
+  bottom: 8px;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: #818cf8;
+}
+
+/* ===== Top bar (white) ===== */
+.app-topbar {
+  border-bottom: 1px solid var(--color-border) !important;
+}
+.topbar-title {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: var(--color-ink);
+  letter-spacing: -0.01em;
+}
+.user-chip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 12px 4px 4px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  margin-right: 4px;
+}
+.user-initials {
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+.user-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-slate);
+}
+@media (max-width: 600px) {
+  .user-name {
+    display: none;
+  }
+}
+</style>

--- a/client/src/components/AccordionTable.vue
+++ b/client/src/components/AccordionTable.vue
@@ -1,54 +1,53 @@
 <template>
-  <v-card class="pa-4 ma-2 accordion-table-card" elevation="3" rounded="lg">
-    <v-card-title class="pa-0 mb-2">
-      <h5 class="text-h5 text-primary font-weight-bold">{{ title }}</h5>
-    </v-card-title>
-    <v-card-subtitle class="pa-0 mb-4">
-      <p class="text-body-2 text-medium-emphasis">
-        {{ subtitle }}
-      </p>
-    </v-card-subtitle>
-    <v-divider class="mb-4" />
-    <v-text-field
-      v-if="enableSearch"
-      v-model="search"
-      label="Search groups..."
-      prepend-inner-icon="mdi-magnify"
-      variant="outlined"
-      hide-details
-      single-line
-      density="compact"
-      clearable
-      class="search-field mb-4"
-      color="primary"
-    ></v-text-field>
+  <div>
+    <!-- Page header -->
+    <div class="page-head">
+      <h1 class="page-title">{{ title }}</h1>
+      <p v-if="subtitle" class="page-subtitle">{{ subtitle }}</p>
+    </div>
 
-    <!-- Bulk Actions Toolbar -->
-    <BulkActionsToolbar
-      v-if="enableActions"
-      :selected-items="appStore.selectedEmployees"
-      :items="items"
-      :actions="actions"
-      @exportData="exportData"
-    />
+    <v-card class="table-card" flat>
+      <div class="pa-4">
+        <v-text-field
+          v-if="enableSearch"
+          v-model="search"
+          placeholder="Search groups…"
+          prepend-inner-icon="mdi-magnify"
+          variant="outlined"
+          hide-details
+          single-line
+          density="comfortable"
+          clearable
+          class="search-field mb-4"
+          color="primary"
+        ></v-text-field>
 
-    <v-data-table
-      :loading="loading"
-      :loading-text="loadingText"
-      :headers="computedHeaders"
-      :items="groupedTableFilteredData"
-      density="compact"
-      show-expand
-      item-value="groupedBy"
-      v-model:expanded="expandedRows"
-      :hide-default-footer="groupedTableFilteredData.length < 11"
-      class="elevation-0 rounded-lg accordion-data-table"
-      hover
-      @update:expanded="handleExpansionUpdate"
-    >
-      <template v-slot:expanded-row="{ columns, item }">
-        <td :colspan="columns.length" style="background-color: #e6f2f0">
-          <v-card class="pa-4" flat color="transparent">
+        <!-- Bulk Actions Toolbar -->
+        <BulkActionsToolbar
+          v-if="enableActions"
+          :selected-items="appStore.selectedEmployees"
+          :items="items"
+          :actions="actions"
+          @exportData="exportData"
+        />
+
+        <v-data-table
+          :loading="loading"
+          :loading-text="loadingText"
+          :headers="computedHeaders"
+          :items="groupedTableFilteredData"
+          density="compact"
+          show-expand
+          item-value="groupedBy"
+          v-model:expanded="expandedRows"
+          :hide-default-footer="groupedTableFilteredData.length < 11"
+          class="elevation-0 accordion-data-table"
+          hover
+          @update:expanded="handleExpansionUpdate"
+        >
+          <template v-slot:expanded-row="{ columns, item }">
+            <td :colspan="columns.length" class="accordion-expanded-cell">
+              <v-card class="pa-2" flat color="transparent">
             <DataTable
               :items="item.items"
               :title="item.groupedBy"
@@ -64,11 +63,13 @@
               :tableActions="[]"
               :tableColumns="tableColumns"
             />
-          </v-card>
-        </td>
-      </template>
-    </v-data-table>
-  </v-card>
+              </v-card>
+            </td>
+          </template>
+        </v-data-table>
+      </div>
+    </v-card>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -202,125 +203,18 @@ const exportData = () => {
 </script>
 
 <style scoped>
-/* Card styling with subtle gradient */
-.accordion-table-card {
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  transition: all 0.3s ease;
-}
-
-.accordion-table-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
-}
-
-/* Enhanced divider with gradient */
-
-/* Search field enhancements */
-.search-field {
-  transition: all 0.3s ease;
-}
-
-.search-field :deep(.v-field__outline) {
-  --v-field-border-opacity: 0.3;
-}
-
-.search-field :deep(.v-field--focused .v-field__outline) {
-  --v-field-border-opacity: 1;
-  border-width: 2px;
-}
-
-.search-field :deep(.v-field__input) {
-  background: rgba(var(--color-primary-rgb), 0.02);
-  border-radius: 8px;
-}
-
-/* Table styling */
+/* Table/card visuals are handled by global CSS; keep this component lean. */
 .accordion-data-table {
   background: transparent;
 }
 
-/* Table headers with enhanced styling (scoped) */
-:deep(.v-data-table-header__content),
-:deep(.v-data-table-column__sort) {
-  font-weight: 700 !important;
-  color: var(--color-secondary) !important;
-  text-transform: uppercase !important;
-  font-size: 0.75rem !important;
-  letter-spacing: 0.5px !important;
+/* Expanded group panel — pale lavender (info background) */
+.accordion-expanded-cell {
+  background-color: var(--color-primary-pale);
+  padding: 4px 8px;
 }
 
-:deep(.v-data-table thead th),
-:deep(.v-data-table__th) {
-  background: #f5f7fa !important;
-}
-
-/* Row hover effects */
-:deep(.v-data-table__tr:hover) {
-  background: linear-gradient(
-    135deg,
-    rgba(var(--color-primary-rgb), 0.04) 0%,
-    rgba(var(--color-primary-rgb), 0.08) 100%
-  ) !important;
-  transform: scale(1.005);
-  transition: all 0.2s ease;
-}
-
-:deep(.v-data-table__td) {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
-  padding: 12px 16px;
-}
-
-/* Alternating row colors for better readability */
-:deep(.v-data-table__tr:nth-child(even)) {
-  background: rgba(248, 250, 252, 0.5);
-}
-
-/* Expand button styling */
-:deep(.v-data-table__expand-icon) {
-  color: var(--color-primary);
-  transition: all 0.3s ease;
-}
-
-:deep(.v-data-table__expand-icon:hover) {
-  color: var(--color-info);
-  transform: scale(1.1);
-}
-
-/* Expanded row styling - keep the original background color */
 :deep(.v-data-table__expanded__content) {
-  background-color: #ebf5f0;
-}
-
-/* Footer styling */
-:deep(.v-data-table-footer) {
-  background: linear-gradient(135deg, #f8fafc 0%, #e8f4fd 100%);
-  border-top: 1px solid rgba(var(--color-primary-rgb), 0.2);
-  border-radius: 0 0 12px 12px;
-}
-
-/* Pagination button styling */
-:deep(.v-pagination__item) {
-  transition: all 0.3s ease;
-}
-
-:deep(.v-pagination__item:hover) {
-  background: rgba(var(--color-primary-rgb), 0.1);
-  transform: scale(1.05);
-}
-
-:deep(.v-pagination__item--is-active) {
-  background: linear-gradient(
-    135deg,
-    var(--color-primary) 0%,
-    var(--color-info) 100%
-  );
-  color: white;
-  box-shadow: 0 2px 8px rgba(var(--color-primary-rgb), 0.3);
-}
-
-/* Loading state styling */
-:deep(.v-data-table__loading) {
-  background: rgba(var(--color-primary-rgb), 0.02);
+  background-color: var(--color-primary-pale);
 }
 </style>

--- a/client/src/components/BulkActionsToolbar.vue
+++ b/client/src/components/BulkActionsToolbar.vue
@@ -3,13 +3,13 @@
     <v-toolbar
       color="primary"
       density="compact"
-      class="mb-4 rounded-lg"
-      elevation="2"
+      class="mb-4 rounded-lg bulk-toolbar"
+      flat
     >
-      <v-toolbar-title class="text-white">
+      <v-toolbar-title class="text-white bulk-toolbar-title">
         <v-fade-transition mode="out-in">
           <span :key="selectedItems.length">
-            {{ selectedItems.length }}
+            <strong class="tabular-nums">{{ selectedItems.length }}</strong>
             selected
           </span>
         </v-fade-transition>
@@ -78,34 +78,14 @@ const actionDisabled = (action: Action) => {
 </script>
 
 <style scoped>
-/* Toolbar styling */
-::deep(.v-toolbar) {
-  transition: all 0.3s ease;
+.bulk-toolbar {
+  box-shadow: var(--shadow-sm);
 }
-
-::deep(.v-toolbar:hover) {
-  transform: translateY(-1px);
-  box-shadow: 0 6px 20px rgba(var(--color-primary-rgb), 0.3);
+.bulk-toolbar-title {
+  font-size: 0.9375rem;
+  font-weight: 500;
 }
-
-/* Button styling */
-::deep(.v-btn) {
-  transition: all 0.3s ease;
-}
-
-::deep(.v-btn:hover) {
-  background: rgba(255, 255, 255, 0.1);
-  transform: scale(1.05);
-}
-
-/* Icon styling */
-::deep(.v-icon) {
-  transition: all 0.3s ease;
-}
-
-/* Toolbar title styling */
-::deep(.v-toolbar-title) {
-  font-weight: 600;
-  letter-spacing: 0.5px;
+.bulk-toolbar-title strong {
+  font-weight: 800;
 }
 </style>

--- a/client/src/components/DataTable.vue
+++ b/client/src/components/DataTable.vue
@@ -1,62 +1,63 @@
 <template>
-  <v-card class="pa-4 ma-2 data-table-card" elevation="3" rounded="lg">
-    <v-card-title v-if="showTitles" class="pa-0 mb-2">
-      <h5 class="text-h5 text-primary font-weight-bold">{{ title }}</h5>
-    </v-card-title>
-    <v-card-subtitle v-if="showTitles" class="pa-0 mb-4">
-      <p class="text-body-2 text-medium-emphasis">
-        {{ subtitle }}
-      </p>
-    </v-card-subtitle>
-    <v-divider v-if="showTitles" class="mb-4" />
-    <v-text-field
-      v-if="enableSearch"
-      v-model="search"
-      label="Search employees..."
-      prepend-inner-icon="mdi-magnify"
-      variant="outlined"
-      hide-details
-      single-line
-      density="compact"
-      class="search-field mb-4"
-      color="primary"
-    ></v-text-field>
+  <div>
+    <!-- Page header (shown for full-page table views) -->
+    <div v-if="showTitles" class="page-head">
+      <h1 class="page-title">{{ title }}</h1>
+      <p v-if="subtitle" class="page-subtitle">{{ subtitle }}</p>
+    </div>
 
-    <!-- Bulk Actions Toolbar -->
-    <BulkActionsToolbar
-      v-if="enableActions"
-      :selected-items="selectedItems"
-      :items="items"
-      :actions="actions"
-      @exportData="exportData"
-    />
+    <v-card class="table-card" flat>
+      <div class="pa-4">
+        <v-text-field
+          v-if="enableSearch"
+          v-model="search"
+          placeholder="Search employees…"
+          prepend-inner-icon="mdi-magnify"
+          variant="outlined"
+          hide-details
+          single-line
+          density="comfortable"
+          class="search-field mb-4"
+          color="primary"
+        ></v-text-field>
 
-    <v-data-table
-      :headers="computedHeaders"
-      :items="filteredItems"
-      density="compact"
-      class="elevation-0 rounded-lg data-table-custom"
-      :show-select="enableSelect"
-      :items-per-page="10"
-      :items-per-page-options="[5, 10, 25, 50]"
-      :hide-default-footer="filteredItems.length < 11"
-      :loading="loading"
-      :loading-text="loadingText"
-      hover
-      v-model="selectedItems"
-      item-value="_id"
-      return-object
-    >
-      <template v-slot:item.actions="{ item }">
-        <v-btn icon size="small" variant="text" @click="viewRecord(item)">
-          <v-icon icon="mdi-eye" color="primary" />
-          <v-tooltip activator="parent" location="top">
-            View Details
-          </v-tooltip>
-        </v-btn>
-      </template>
-    </v-data-table>
-  </v-card>
+        <!-- Bulk Actions Toolbar -->
+        <BulkActionsToolbar
+          v-if="enableActions"
+          :selected-items="selectedItems"
+          :items="items"
+          :actions="actions"
+          @exportData="exportData"
+        />
+
+        <v-data-table
+          :headers="computedHeaders"
+          :items="filteredItems"
+          density="compact"
+          class="elevation-0 data-table-custom"
+          :show-select="enableSelect"
+          :items-per-page="10"
+          :items-per-page-options="[5, 10, 25, 50]"
+          :hide-default-footer="filteredItems.length < 11"
+          :loading="loading"
+          :loading-text="loadingText"
+          hover
+          v-model="selectedItems"
+          item-value="_id"
+          return-object
+        >
+          <template v-slot:item.actions="{ item }">
+            <v-btn icon size="small" variant="text" @click="viewRecord(item)">
+              <v-icon icon="mdi-eye-outline" color="primary" />
+              <v-tooltip activator="parent" location="top">
+                View Details
+              </v-tooltip>
+            </v-btn>
+          </template>
+        </v-data-table>
+      </div>
+    </v-card>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -190,104 +191,8 @@ watch(
 </script>
 
 <style scoped>
-/* Card styling with subtle gradient */
-.data-table-card {
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  transition: all 0.3s ease;
-}
-
-.data-table-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
-}
-
-/* Enhanced divider with gradient */
-
-/* Search field enhancements */
-.search-field {
-  transition: all 0.3s ease;
-}
-
-.search-field :deep(.v-field__outline) {
-  --v-field-border-opacity: 0.3;
-}
-
-.search-field :deep(.v-field--focused .v-field__outline) {
-  --v-field-border-opacity: 1;
-  border-width: 2px;
-}
-
-.search-field :deep(.v-field__input) {
-  background: rgba(var(--color-primary-rgb), 0.02);
-  border-radius: 8px;
-}
-
-/* Table styling */
+/* Table/card visuals are handled by global CSS; keep this component lean. */
 .data-table-custom {
   background: transparent;
-}
-
-/* Table headers with enhanced styling (scoped) */
-:deep(.v-data-table-header__content),
-:deep(.v-data-table-column__sort) {
-  font-weight: 700 !important;
-  color: var(--color-secondary) !important;
-  text-transform: uppercase !important;
-  font-size: 0.75rem !important;
-  letter-spacing: 0.5px !important;
-}
-
-:deep(.v-data-table thead th),
-:deep(.v-data-table__th) {
-  background: #f5f7fa !important;
-}
-
-/* Row hover effects */
-:deep(.v-data-table__tr:hover) {
-  background: linear-gradient(
-    135deg,
-    rgba(var(--color-primary-rgb), 0.04) 0%,
-    rgba(var(--color-primary-rgb), 0.08) 100%
-  ) !important;
-  transform: scale(1.005);
-  transition: all 0.2s ease;
-}
-
-:deep(.v-data-table__td) {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
-  padding: 12px 16px;
-}
-
-/* Alternating row colors for better readability */
-:deep(.v-data-table__tr:nth-child(even)) {
-  background: rgba(248, 250, 252, 0.5);
-}
-
-/* Footer styling */
-:deep(.v-data-table-footer) {
-  background: linear-gradient(135deg, #f8fafc 0%, #e8f4fd 100%);
-  border-top: 1px solid rgba(var(--color-primary-rgb), 0.2);
-  border-radius: 0 0 12px 12px;
-}
-
-/* Pagination button styling */
-:deep(.v-pagination__item) {
-  transition: all 0.3s ease;
-}
-
-:deep(.v-pagination__item:hover) {
-  background: rgba(var(--color-primary-rgb), 0.1);
-  transform: scale(1.05);
-}
-
-:deep(.v-pagination__item--is-active) {
-  background: linear-gradient(
-    135deg,
-    var(--color-primary) 0%,
-    var(--color-info) 100%
-  );
-  color: white;
-  box-shadow: 0 2px 8px rgba(var(--color-primary-rgb), 0.3);
 }
 </style>

--- a/client/src/components/OrgChartNode.vue
+++ b/client/src/components/OrgChartNode.vue
@@ -290,9 +290,11 @@ const getJobLevelColor = (jobLevel: JobLevel): string => {
   width: 200px;
   min-height: 100px;
   cursor: pointer;
-  transition: all 0.3s ease;
-  border: 2px solid transparent;
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease,
+    transform 0.2s ease;
+  border: 1px solid var(--color-border);
+  background: var(--color-white);
+  box-shadow: var(--shadow-xs);
   position: relative;
   z-index: 2;
   overflow: visible; /* allow pseudo-element to render above card */
@@ -331,15 +333,15 @@ const getJobLevelColor = (jobLevel: JobLevel): string => {
 }
 
 .employee-card:hover {
-  transform: translateY(-4px) scale(1.02);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.15);
-  border-color: rgba(var(--color-primary-rgb), 0.3);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+  border-color: rgba(var(--color-primary-rgb), 0.45);
 }
 
 .employee-card.highlighted {
   border-color: var(--color-primary);
-  background: linear-gradient(135deg, #e3f2fd 0%, #f8fafc 100%);
-  box-shadow: 0 8px 25px rgba(var(--color-primary-rgb), 0.2);
+  background: var(--color-primary-pale);
+  box-shadow: 0 0 0 1px var(--color-primary), var(--shadow-sm);
 }
 
 .employee-avatar {

--- a/client/src/components/baseDialog/BaseDialog.vue
+++ b/client/src/components/baseDialog/BaseDialog.vue
@@ -5,18 +5,18 @@
     :persistent="dialogStore.dialogState.persistent ?? true"
     :width="dialogWidth"
   >
-    <v-card>
-      <v-card-title class="d-flex">
-        <p>{{ dialogStore.dialogState.header }}</p>
-        <v-spacer></v-spacer>
-        <v-icon
+    <v-card class="dialog-card" rounded="lg">
+      <div class="dialog-header">
+        <span class="dialog-title">{{ dialogStore.dialogState.header }}</span>
+        <v-btn
           icon="mdi-close"
-          size="x-small"
-          class="mt-1"
+          variant="text"
+          size="small"
+          density="comfortable"
           @click="dialogStore.closeAndResetDialog()"
-        ></v-icon>
-      </v-card-title>
-      <v-card-text class="ml-n1 mr-n1">
+        ></v-btn>
+      </div>
+      <v-card-text class="dialog-body">
         <slot />
       </v-card-text>
     </v-card>
@@ -45,3 +45,22 @@ const dialogWidth = computed(() => {
   }
 });
 </script>
+
+<style scoped>
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--color-border);
+}
+.dialog-title {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--color-ink);
+}
+.dialog-body {
+  padding: 20px !important;
+}
+</style>

--- a/client/src/components/charts/DepartmentComparisonChart.vue
+++ b/client/src/components/charts/DepartmentComparisonChart.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="chart-container">
-    <v-card class="pa-4 chart-card" elevation="3" rounded="lg">
-      <v-card-title class="text-h6 pb-2 text-primary font-weight-bold">
+    <v-card class="chart-card" flat>
+      <div class="card-head">
+        <v-icon size="20">mdi-chart-bar</v-icon>
         Performance by Department
-      </v-card-title>
+      </div>
       <div class="chart-wrapper" style="position: relative; height: 350px">
         <Bar :data="chartData" :options="chartOptions" />
       </div>
@@ -200,24 +201,10 @@ const chartOptions = computed(() => ({
   width: 100%;
 }
 
-/* Chart card styling */
-.chart-card {
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  transition: all 0.3s ease;
-}
-
-.chart-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
-}
-
 .chart-wrapper {
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba(255, 255, 255, 0.8);
-  border-radius: 8px;
-  padding: 8px;
+  padding: 16px;
 }
 </style>

--- a/client/src/components/charts/DepartmentDistributionChart.vue
+++ b/client/src/components/charts/DepartmentDistributionChart.vue
@@ -29,20 +29,18 @@ const props = defineProps<{
 const chartCanvas = ref<HTMLCanvasElement | null>(null);
 let chartInstance: ChartJS | null = null;
 
-// Teal-aligned categorical palette
+// Indigo + gold categorical palette (EMS chart series order)
 const colors = [
-  getComputedStyle(document.documentElement)
-    .getPropertyValue("--color-primary")
-    .trim() || "#00897b",
-  "#26c6da", // accent cyan
-  "#4caf50", // success green
-  "#ffb74d", // soft orange
-  "#5e35b1", // indigo/purple accent
-  "#009688", // teal variant
-  "#90a4ae", // blue-grey
-  "#8d6e63", // brown
-  "#42a5f5", // light blue for contrast
-  "#ef5350", // soft red
+  "#4F46E5", // indigo (primary series)
+  "#EAB308", // gold
+  "#059669", // green
+  "#EC4899", // pink
+  "#0891B2", // cyan
+  "#818CF8", // soft violet
+  "#A16207", // deep gold
+  "#0EA5E9", // info blue
+  "#DB2777", // deep pink
+  "#A1A1AA", // gray (other/neutral)
 ];
 
 const createChart = () => {

--- a/client/src/components/charts/EmploymentStatusChart.vue
+++ b/client/src/components/charts/EmploymentStatusChart.vue
@@ -41,7 +41,7 @@ const statusColors: Record<string, string> = {
   Inactive: warning,
   Terminated: error,
   "On Leave": info,
-  Probation: "#5e35b1", // indigo for distinction
+  Probation: "#4F46E5", // indigo for distinction
 };
 
 const createChart = () => {
@@ -95,7 +95,6 @@ const createChart = () => {
               if (data.labels && data.datasets.length) {
                 return data.labels.map((label, i) => {
                   const dataset = data.datasets[0];
-                  const value = dataset.data[i] as number;
                   const percentage = props.statusData[i]?.percentage || 0;
                   return {
                     text: `${label} (${percentage}%)`,

--- a/client/src/components/charts/JobLevelChart.vue
+++ b/client/src/components/charts/JobLevelChart.vue
@@ -44,15 +44,17 @@ const primary = css.getPropertyValue("--color-primary").trim() || "#00897b";
 const success = css.getPropertyValue("--color-success").trim() || "#4caf50";
 const info = css.getPropertyValue("--color-info").trim() || "#1565c0";
 
+// Ordinal seniority scale: cool neutrals → indigo → gold at the top
 const levelColors: Record<string, string> = {
-  Entry: success,
-  Mid: info,
-  Senior: "#ffb74d",
-  Lead: "#5e35b1",
-  Manager: "#ef5350",
-  Director: "#8d6e63",
-  VP: "#90a4ae",
-  "C-Level": "#26c6da",
+  Entry: "#94A3B8",
+  Mid: info, // info blue
+  Senior: "#0891B2", // cyan
+  Lead: success, // green
+  Manager: primary, // indigo
+  Director: "#6366F1",
+  VP: "#818CF8", // soft violet
+  "C-Level": "#A16207", // deep gold
+  CEO: "#EAB308", // gold (top)
 };
 
 const createChart = () => {

--- a/client/src/components/charts/PerformanceDistributionChart.vue
+++ b/client/src/components/charts/PerformanceDistributionChart.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="chart-container">
-    <v-card class="pa-4 chart-card" elevation="3" rounded="lg">
-      <v-card-title class="text-h6 pb-2 text-primary font-weight-bold">
+    <v-card class="chart-card" flat>
+      <div class="card-head">
+        <v-icon size="20">mdi-chart-donut</v-icon>
         Performance Rating Distribution
-      </v-card-title>
+      </div>
       <div class="chart-wrapper" style="position: relative; height: 300px">
         <Doughnut
           :data="chartData"
@@ -154,24 +155,10 @@ const chartPlugins = computed(() => [
   width: 100%;
 }
 
-/* Chart card styling */
-.chart-card {
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  transition: all 0.3s ease;
-}
-
-.chart-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
-}
-
 .chart-wrapper {
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba(255, 255, 255, 0.8);
-  border-radius: 8px;
-  padding: 8px;
+  padding: 16px;
 }
 </style>

--- a/client/src/components/charts/PerformanceTrendChart.vue
+++ b/client/src/components/charts/PerformanceTrendChart.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="chart-container">
-    <v-card class="pa-4 chart-card" elevation="3" rounded="lg">
-      <v-card-title class="text-h6 pb-2 text-primary font-weight-bold">
+    <v-card class="chart-card" flat>
+      <div class="card-head">
+        <v-icon size="20">mdi-chart-line</v-icon>
         Performance Trends Over Time
-      </v-card-title>
+      </div>
       <div class="chart-wrapper" style="position: relative; height: 300px">
         <Line :data="chartData" :options="chartOptions" />
       </div>
@@ -195,24 +196,10 @@ const chartOptions = computed(() => ({
   width: 100%;
 }
 
-/* Chart card styling */
-.chart-card {
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  transition: all 0.3s ease;
-}
-
-.chart-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
-}
-
 .chart-wrapper {
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba(255, 255, 255, 0.8);
-  border-radius: 8px;
-  padding: 8px;
+  padding: 16px;
 }
 </style>

--- a/client/src/plugins/vuetify.ts
+++ b/client/src/plugins/vuetify.ts
@@ -19,27 +19,35 @@ export default createVuetify({
     defaultTheme: "light",
     themes: {
       light: {
+        dark: false,
         colors: {
-          primary: "#00897b", // Teal
-          secondary: "#37474f", // Dark blue-gray
-          accent: "#26c6da", // Light cyan
-          error: "#f44336",
-          warning: "#ff9800",
-          info: "#1565c0",
-          success: "#4caf50",
+          primary: "#4F46E5", // Indigo
+          secondary: "#3F3F46", // Slate (neutral text)
+          accent: "#EAB308", // Gold
+          error: "#DC2626",
+          warning: "#D97706",
+          info: "#0EA5E9",
+          success: "#059669",
+          background: "#F4F4F5", // Page surface
+          surface: "#FFFFFF", // Cards, panels
+          "surface-variant": "#F1F1F4",
+          "on-surface": "#18181B", // Ink
+          "on-background": "#18181B",
+        },
+        variables: {
+          "border-color": "#E4E4E7",
+          "border-opacity": 1,
+          "high-emphasis-opacity": 0.92,
+          "medium-emphasis-opacity": 0.66,
         },
       },
-      // dark: {
-      //   colors: {
-      //     primary: "#42b883",
-      //     secondary: "#34495e",
-      //     accent: "#646cff",
-      //     error: "#f44336",
-      //     warning: "#ff9800",
-      //     info: "#2196f3",
-      //     success: "#4caf50",
-      //   },
-      // },
     },
+  },
+  defaults: {
+    VCard: { rounded: "lg" },
+    VTextField: { color: "primary" },
+    VSelect: { color: "primary" },
+    VTextarea: { color: "primary" },
+    VAutocomplete: { color: "primary" },
   },
 });

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -189,7 +189,7 @@ const router = createRouter({
 });
 
 // Navigation guard for authentication
-router.beforeEach((to, from, next) => {
+router.beforeEach((to, _from, next) => {
   const authStore = useAuthStore();
   const requiresAuth = to.matched.some((record) => record.meta.requiresAuth);
   const guestOnly = to.matched.some((record) => record.meta.guestOnly);

--- a/client/src/styles/auth.css
+++ b/client/src/styles/auth.css
@@ -1,0 +1,203 @@
+/* Auth pages — enterprise split-screen (brand panel + form) */
+
+.auth-shell {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  grid-template-columns: 1.05fr 1fr;
+  background: var(--color-white);
+  overflow-y: auto;
+}
+
+/* ----- Brand panel (midnight indigo) ----- */
+.auth-brand {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 48px 56px;
+  background: radial-gradient(
+      120% 120% at 100% 0%,
+      #2a2566 0%,
+      var(--color-sidebar) 55%
+    ),
+    var(--color-sidebar);
+  color: #e8e8f5;
+  overflow: hidden;
+}
+.auth-brand::after {
+  /* soft gold glow accent */
+  content: "";
+  position: absolute;
+  right: -120px;
+  bottom: -120px;
+  width: 360px;
+  height: 360px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(234, 179, 8, 0.16) 0%,
+    transparent 70%
+  );
+}
+
+.auth-brand-top {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  position: relative;
+  z-index: 1;
+}
+.auth-brand-tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 11px;
+  background: rgba(129, 140, 248, 0.18);
+  border: 1px solid rgba(129, 140, 248, 0.32);
+}
+.auth-brand-lockup {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+.auth-brand-name {
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: #fff;
+}
+.auth-brand-sub {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+  color: #a5a3d4;
+}
+
+.auth-brand-mid {
+  position: relative;
+  z-index: 1;
+  max-width: 460px;
+}
+.auth-headline {
+  font-size: 2.5rem;
+  font-weight: 800;
+  line-height: 1.12;
+  letter-spacing: -0.02em;
+  color: #fff;
+  margin-bottom: 18px;
+}
+.auth-subhead {
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #b9b7e0;
+  margin-bottom: 28px;
+}
+.auth-features {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.auth-features li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: #d8d7ef;
+}
+
+.auth-brand-foot {
+  position: relative;
+  z-index: 1;
+  font-size: 0.75rem;
+  color: #7c7aae;
+}
+
+/* ----- Form panel ----- */
+.auth-form-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 32px;
+  background: var(--color-white);
+}
+.auth-form {
+  width: 100%;
+  max-width: 400px;
+}
+.auth-form-head {
+  margin-bottom: 24px;
+}
+.auth-title {
+  font-size: 1.75rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--color-ink);
+}
+.auth-desc {
+  font-size: 0.9375rem;
+  color: var(--color-gray);
+  margin-top: 4px;
+}
+
+.demo-box {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  margin-bottom: 20px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-primary-pale);
+}
+.demo-title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #3730a3;
+}
+.demo-creds {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-slate);
+  font-variant-numeric: tabular-nums;
+}
+
+.auth-foot {
+  margin-top: 24px;
+  text-align: center;
+  font-size: 0.875rem;
+  color: var(--color-slate);
+}
+.auth-link {
+  color: var(--color-primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+.auth-link:hover {
+  text-decoration: underline;
+}
+
+/* Password hint on register */
+.auth-hint {
+  font-size: 0.8125rem;
+  color: var(--color-gray);
+  margin: -4px 0 12px;
+}
+
+/* ----- Responsive ----- */
+@media (max-width: 960px) {
+  .auth-shell {
+    grid-template-columns: 1fr;
+  }
+  .auth-brand {
+    display: none;
+  }
+}

--- a/client/src/styles/cards.css
+++ b/client/src/styles/cards.css
@@ -1,65 +1,63 @@
-/* Card Components Styles */
+/* Card Components — flat, bordered, single elevation scale (enterprise console) */
 
-/* Base card styling with gradient background */
+/* Base surfaces: solid white, hairline border, subtle shadow */
 .header-card,
 .chart-card,
 .info-card,
 .filters-card,
 .table-card,
-.main-form-card {
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  transition: all 0.3s ease;
+.main-form-card,
+.section-card {
+  background: var(--color-white) !important;
+  border: 1px solid var(--color-border) !important;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xs);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.header-card:hover,
+/* Quiet hover — lift shadow only, no transform (reads professional, not playful) */
 .chart-card:hover,
 .info-card:hover,
 .filters-card:hover,
 .table-card:hover,
-.main-form-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
+.section-card:hover {
+  box-shadow: var(--shadow-sm);
+  border-color: #d4d4d8;
 }
 
-/* Summary cards with enhanced hover effects */
+/* KPI / summary cards — flat with a left accent bar via the component markup */
 .summary-card {
-  transition: all 0.3s ease;
-  border: 1px solid rgba(0, 0, 0, 0.05);
+  background: var(--color-white) !important;
+  border: 1px solid var(--color-border) !important;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xs);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .summary-card:hover {
-  transform: translateY(-4px) scale(1.02);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
+  border-color: rgba(var(--color-primary-rgb), 0.35);
 }
 
-/* Section cards with secondary color accents */
-.section-card {
-  background: linear-gradient(135deg, #ffffff 0%, #fafbfc 100%);
-  border: 1px solid rgba(var(--color-secondary-rgb), 0.1);
-  transition: all 0.3s ease;
+/* Header card — a touch of indigo presence for page headers */
+.header-card {
+  background: var(--color-white) !important;
 }
 
-.section-card:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 15px rgba(var(--color-secondary-rgb), 0.1);
-  border-color: rgba(var(--color-secondary-rgb), 0.2);
-}
-
-/* Special summary card variant for dialogs */
+/* Dialog summary variants — pale lavender info block */
 .summary-card.dialog-summary,
 .summary-card.assign-manager-summary {
-  background: linear-gradient(135deg, #f8fafc 0%, #e8f4fd 100%);
-  border: 1px solid rgba(var(--color-secondary-rgb), 0.2);
+  background: var(--color-primary-pale) !important;
+  border: 1px solid rgba(var(--color-primary-rgb), 0.25) !important;
+  box-shadow: none;
 }
 
-/* Chart and info cards with full height */
+/* Chart and info cards full height */
 .chart-card,
 .info-card {
   height: 100%;
 }
 
-/* Prevent card content cutoff */
 .chart-card {
   overflow: visible !important;
 }
@@ -71,4 +69,134 @@
 /* Card spacing */
 .v-card {
   margin-bottom: 16px;
+}
+
+/* Generic Vuetify cards inherit the flat console treatment */
+.v-card.v-card--variant-elevated {
+  box-shadow: var(--shadow-sm);
+}
+
+/* ===== KPI / metric cards (shared by Home, Analytics, Performance) ===== */
+.kpi-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px !important;
+  background: var(--color-white) !important;
+  border: 1px solid var(--color-border) !important;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xs);
+  position: relative;
+  overflow: hidden;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+.kpi-card:hover {
+  box-shadow: var(--shadow-md);
+  border-color: rgba(var(--color-primary-rgb), 0.35);
+}
+.kpi-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  border-radius: 12px;
+  flex-shrink: 0;
+  background: rgba(var(--color-primary-rgb), 0.1);
+  color: var(--color-primary);
+}
+.kpi-icon--success {
+  background: rgba(var(--color-success-rgb), 0.12);
+  color: var(--color-success);
+}
+.kpi-icon--info {
+  background: rgba(var(--color-info-rgb), 0.12);
+  color: var(--color-info);
+}
+.kpi-icon--warning {
+  background: rgba(var(--color-warning-rgb), 0.12);
+  color: var(--color-warning);
+}
+.kpi-icon--error {
+  background: rgba(var(--color-error-rgb), 0.12);
+  color: var(--color-error);
+}
+.kpi-body {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.kpi-label {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--color-gray);
+  margin-bottom: 2px;
+}
+.kpi-value {
+  font-size: 1.75rem;
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--color-ink);
+}
+.kpi-sub {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-gray);
+  margin-top: 2px;
+}
+/* Gold hero metric */
+.kpi-card--gold .kpi-icon {
+  background: var(--color-accent-pale);
+  color: var(--color-accent-text);
+}
+.kpi-card--gold::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--color-accent);
+}
+.kpi-card--gold .kpi-value {
+  color: var(--color-accent-text);
+}
+
+/* ===== Page header (eyebrow + title + subtitle) ===== */
+.page-head {
+  margin-bottom: 20px;
+}
+.page-head .eyebrow {
+  display: block;
+  margin-bottom: 4px;
+}
+.page-title {
+  font-size: 1.625rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--color-ink);
+  line-height: 1.15;
+}
+.page-subtitle {
+  font-size: 0.9375rem;
+  color: var(--color-gray);
+  margin-top: 2px;
+}
+
+/* Section/card heading row */
+.card-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-ink);
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--color-border);
+}
+.card-head .v-icon {
+  color: var(--color-primary);
 }

--- a/client/src/styles/components.css
+++ b/client/src/styles/components.css
@@ -1,135 +1,100 @@
-/* Component-specific Styles */
+/* Component-specific Styles — tables, chips, pagination, alerts */
 
-/* Enhanced divider with gradient */
-/* .divider-gradient {
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    var(--color-primary) 50%,
-    transparent 100%
-  ) !important;
-  height: 2px !important;
-  border: none !important;
-  opacity: 1 !important;
-} */
-
-/* Target Vuetify's v-divider internal structure */
-/* .v-divider.divider-gradient {
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    var(--color-primary) 50%,
-    transparent 100%
-  ) !important;
-  height: 2px !important;
-  border: none !important;
-  opacity: 1 !important;
-  max-height: 2px !important;
-  min-height: 2px !important;
-} */
-
-/* Loading state styling */
+/* Loading spinner */
 .v-progress-circular {
-  filter: drop-shadow(0 4px 8px rgba(var(--color-primary-rgb), 0.3));
+  color: var(--color-primary);
 }
 
-/* Table styling */
+/* ----- Data tables: dense, scannable, enterprise ----- */
 .performance-data-table {
   background: transparent;
 }
 
-/* Table headers with enhanced styling (global) */
+/* Column headers: compact uppercase labels */
 .v-data-table-header__content,
 .v-data-table-column__sort {
   font-weight: 700 !important;
-  color: var(--color-secondary) !important;
+  color: var(--color-slate) !important;
   text-transform: uppercase !important;
-  font-size: 0.75rem !important;
-  letter-spacing: 0.5px !important;
+  font-size: 0.6875rem !important;
+  letter-spacing: 0.6px !important;
 }
 
 .v-data-table thead th,
 .v-data-table__th {
-  background: #f5f7fa !important;
+  background: var(--color-surface) !important;
+  border-bottom: 1px solid var(--color-border) !important;
 }
 
-/* Row hover effects */
-.v-data-table__tr:hover {
-  background: linear-gradient(
-    135deg,
-    rgba(var(--color-primary-rgb), 0.04) 0%,
-    rgba(var(--color-primary-rgb), 0.08) 100%
-  ) !important;
-  transform: scale(1.005);
-  transition: all 0.2s ease;
+/* Rows: quiet hover (tint only, no transform) */
+.v-data-table__tr:hover,
+.v-data-table tbody tr:hover {
+  background: rgba(var(--color-primary-rgb), 0.05) !important;
+  transition: background 0.15s ease;
 }
 
-.v-data-table__td {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
-  padding: 12px 16px;
+.v-data-table__td,
+.v-data-table tbody td {
+  border-bottom: 1px solid var(--color-border);
+  padding: 10px 16px;
+  color: var(--color-ink);
 }
 
-/* Alternating row colors for better readability */
-.v-data-table__tr:nth-child(even) {
-  background: rgba(248, 250, 252, 0.5);
+/* Subtle zebra striping */
+.v-data-table__tr:nth-child(even) > td {
+  background: rgba(244, 244, 245, 0.5);
 }
 
-/* Footer styling */
+.v-data-table__tr:hover:nth-child(even) > td {
+  background: transparent;
+}
+
+/* Footer */
 .v-data-table-footer {
-  background: linear-gradient(135deg, #f8fafc 0%, #e8f4fd 100%);
-  border-top: 1px solid rgba(var(--color-primary-rgb), 0.2);
-  border-radius: 0 0 12px 12px;
+  background: var(--color-white);
+  border-top: 1px solid var(--color-border);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  font-size: 0.8125rem;
 }
 
-/* Pagination button styling */
+/* ----- Pagination ----- */
 .v-pagination__item {
-  transition: all 0.3s ease;
+  transition: background 0.2s ease;
 }
 
 .v-pagination__item:hover {
   background: rgba(var(--color-primary-rgb), 0.1);
-  transform: scale(1.05);
 }
 
 .v-pagination__item--is-active {
-  background: linear-gradient(
-    135deg,
-    var(--color-primary) 0%,
-    var(--color-info) 100%
-  );
-  color: white;
-  box-shadow: 0 2px 8px rgba(var(--color-primary-rgb), 0.3);
+  background: var(--color-primary);
+  color: #fff;
+  box-shadow: none;
 }
 
-/* Chart container styling */
+/* ----- Charts ----- */
 .chart-container {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-/* List styling */
+/* ----- Lists ----- */
 .v-list-item-title {
   font-weight: 500;
 }
 
 .v-list-item-subtitle {
-  opacity: 0.7;
+  opacity: 0.75;
 }
 
-/* Chip enhancements */
+/* ----- Chips / status badges: flat pills, no hover scale ----- */
 .v-chip {
   font-weight: 600;
-  letter-spacing: 0.5px;
-  transition: all 0.3s ease;
+  letter-spacing: 0.2px;
+  border-radius: 6px;
 }
 
-.v-chip:hover {
-  transform: scale(1.05);
-  box-shadow: 0 2px 8px rgba(var(--color-primary-rgb), 0.3);
-}
-
-/* Closable chip styling */
 .v-chip--closable {
   padding-right: 4px;
 }
@@ -137,26 +102,46 @@
 .v-chip__close {
   margin-left: 8px;
   opacity: 0.7;
-  transition: all 0.2s ease;
+  transition: opacity 0.15s ease;
 }
 
 .v-chip__close:hover {
   opacity: 1;
-  background: rgba(var(--color-error-rgb), 0.1);
-  color: var(--color-error);
 }
 
-/* Error alert styling */
+/* ----- Alerts ----- */
 .v-alert {
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(var(--color-error-rgb), 0.2);
+  border-radius: var(--radius-sm);
+  box-shadow: none;
 }
 
-/* Clear all button styling */
-.v-btn--variant-text {
-  transition: all 0.3s ease;
+/* ----- Info-card list rows (analytics / performance summaries) ----- */
+.stat-row {
+  border-radius: var(--radius-sm);
+  min-height: 44px;
 }
-
-.v-btn--variant-text:hover {
-  background: rgba(var(--color-error-rgb), 0.1);
+.stat-row:hover {
+  background: var(--color-surface);
+}
+.stat-row + .stat-row {
+  border-top: 1px solid var(--color-border);
+}
+.stat-row-title {
+  font-size: 0.875rem !important;
+  font-weight: 600;
+  color: var(--color-ink);
+}
+.stat-row-sub {
+  font-size: 0.75rem !important;
+  color: var(--color-gray) !important;
+}
+.stat-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--color-primary);
+  background: rgba(var(--color-primary-rgb), 0.1);
 }

--- a/client/src/styles/forms.css
+++ b/client/src/styles/forms.css
@@ -1,106 +1,86 @@
-/* Form Components Styles */
+/* Form Components — clean fields with indigo focus */
 
-/* Form field base styling */
 .form-field,
 .search-field,
 .filter-field {
-  transition: all 0.3s ease;
+  transition: all 0.2s ease;
 }
 
-/* Form field outline styling */
+/* Field outlines: quiet by default, indigo + 2px on focus */
 .form-field :deep(.v-field__outline),
 .search-field :deep(.v-field__outline),
-.filter-field :deep(.v-field__outline) {
-  --v-field-border-opacity: 0.3;
+.filter-field :deep(.v-field__outline),
+.v-text-field .v-field__outline,
+.v-select .v-field__outline,
+.v-textarea .v-field__outline,
+.v-autocomplete .v-field__outline {
+  --v-field-border-opacity: 0.5;
 }
 
 .form-field :deep(.v-field--focused .v-field__outline),
 .search-field :deep(.v-field--focused .v-field__outline),
-.filter-field :deep(.v-field--focused .v-field__outline) {
+.filter-field :deep(.v-field--focused .v-field__outline),
+.v-field--focused .v-field__outline {
   --v-field-border-opacity: 1;
   border-width: 2px;
 }
 
-/* Form field input background */
+/* Subtle field fill */
 .form-field :deep(.v-field__input),
 .search-field :deep(.v-field__input),
-.filter-field :deep(.v-field__input) {
-  background: rgba(var(--color-primary-rgb), 0.02);
-  border-radius: 8px;
-}
-
-/* Global form field styling for consistency */
-::deep(.v-text-field .v-field__outline),
-::deep(.v-select .v-field__outline),
-::deep(.v-textarea .v-field__outline) {
-  --v-field-border-opacity: 0.3;
-}
-
-::deep(.v-text-field .v-field--focused .v-field__outline),
-::deep(.v-select .v-field--focused .v-field__outline),
-::deep(.v-textarea .v-field--focused .v-field__outline) {
-  --v-field-border-opacity: 1;
-  border-width: 2px;
-}
-
-::deep(.v-text-field .v-field__input),
-::deep(.v-select .v-field__input),
-::deep(.v-textarea .v-field__input) {
-  background: rgba(var(--color-primary-rgb), 0.02);
-  border-radius: 8px;
+.filter-field :deep(.v-field__input),
+.v-text-field .v-field__input,
+.v-select .v-field__input,
+.v-textarea .v-field__input {
+  border-radius: var(--radius-sm);
 }
 
 /* Readonly field styling */
-::deep(.v-field--readonly) {
-  background: #f5f7fa !important;
-  opacity: 0.8;
+.v-field--readonly {
+  background: var(--color-surface) !important;
 }
 
 .bg-grey-lighten-5 {
-  background-color: #f5f7fa !important;
+  background-color: var(--color-surface) !important;
 }
 
-/* Form validation styling */
-::deep(.v-messages__message) {
+/* Validation messages */
+.v-messages__message {
   color: var(--color-error);
   font-weight: 500;
 }
 
-/* Enhanced spacing and typography */
-::deep(.v-label) {
+/* Labels */
+.v-label {
   font-weight: 500;
-  color: #424242;
+  color: var(--color-slate);
 }
 
-::deep(.v-field--focused .v-label) {
-  color: var(--color-success);
+.v-field--focused .v-label {
+  color: var(--color-primary);
 }
 
-/* Section headers styling */
+/* Section headers — flat label band, indigo accent rule */
 .section-header {
-  background: linear-gradient(135deg, #f5f7fa 0%, #e8f4fd 100%);
-  color: var(--color-secondary);
+  background: var(--color-surface);
+  color: var(--color-slate);
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
-  font-size: 0.875rem;
-  border-bottom: 1px solid rgba(var(--color-secondary-rgb), 0.2);
+  letter-spacing: 0.6px;
+  font-size: 0.8125rem;
+  border-bottom: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-primary);
 }
 
-.section-header :deep(.v-icon) {
-  color: var(--color-secondary);
+.section-header :deep(.v-icon),
+.section-header .v-icon {
+  color: var(--color-primary);
 }
 
-/* Header section styling for forms */
+/* Form page header band */
 .header-section {
-  background: linear-gradient(135deg, #f8fafc 0%, #e8f4fd 100%);
-  border-bottom: 2px solid var(--color-secondary);
+  background: var(--color-white);
+  border-bottom: 1px solid var(--color-border);
   margin: -16px -16px 0 -16px;
   padding: 16px 24px;
-}
-
-/* Hover effects for form sections */
-.section-card .v-card-text:hover {
-  background: rgba(var(--color-secondary-rgb), 0.01);
-  transition: background 0.3s ease;
 }

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -5,24 +5,147 @@
 @import "./forms.css";
 @import "./components.css";
 @import "./utilities.css";
+@import "./auth.css";
 
-/* Theme variables aligned with Vuetify teal theme */
+/* ==========================================================================
+   EMS Design Tokens — Indigo primary + warm gold accent. Light enterprise
+   console. Variable names are kept stable (primary/secondary/accent/...) so
+   existing rgba() usages keep working; only the values changed.
+   ========================================================================== */
 :root {
-  /* Base hex colors */
-  --color-primary: #00897b; /* Teal */
-  --color-secondary: #37474f; /* Dark blue-gray */
-  --color-accent: #26c6da; /* Light cyan */
-  --color-error: #f44336;
-  --color-warning: #ff9800;
-  --color-info: #1565c0;
-  --color-success: #4caf50;
+  /* Brand primary — indigo */
+  --color-primary: #4f46e5; /* buttons, links, actions, focus rings */
+  --color-primary-hover: #818cf8; /* hover, secondary, active nav indicator */
+  --color-primary-pale: #e0e0fb; /* selected rows, info bg, complete badge */
+  --color-sidebar: #1e1b4b; /* midnight indigo — sidebar / dark nav */
+  --color-sidebar-2: #2a2566; /* slightly lifted sidebar surface */
+
+  /* Accent — gold (complement to indigo) */
+  --color-accent: #eab308; /* fills, chart accents, icons (not small text) */
+  --color-accent-text: #a16207; /* gold TEXT only (contrast on white) */
+  --color-accent-pale: #fef6da; /* accent background blocks, callouts */
+
+  /* Neutrals */
+  --color-ink: #18181b; /* primary text */
+  --color-slate: #3f3f46; /* secondary text */
+  --color-gray: #a1a1aa; /* labels, hints, placeholders */
+  --color-border: #e4e4e7; /* dividers, input borders */
+  --color-surface: #f4f4f5; /* page background */
+  --color-white: #ffffff; /* cards, panels */
+
+  /* Legacy alias kept for existing markup — maps to slate */
+  --color-secondary: #3f3f46;
+
+  /* Semantic */
+  --color-success: #059669; /* active, hired, complete */
+  --color-warning: #d97706; /* pending, expiring soon */
+  --color-error: #dc2626; /* errors, terminations */
+  --color-info: #0ea5e9; /* tooltips, info states */
+
+  /* Status badge recipes (text / bg) */
+  --badge-active-text: #065f46;
+  --badge-active-bg: #d1fae5;
+  --badge-pending-text: #92400e;
+  --badge-pending-bg: #fef3c7;
+  --badge-complete-text: #3730a3;
+  --badge-complete-bg: #e0e0fb;
+  --badge-terminated-text: #991b1b;
+  --badge-terminated-bg: #fee2e2;
 
   /* RGB triplets for alpha usage */
-  --color-primary-rgb: 0, 137, 123;
-  --color-secondary-rgb: 55, 71, 79;
-  --color-accent-rgb: 38, 198, 218;
-  --color-error-rgb: 244, 67, 54;
-  --color-warning-rgb: 255, 152, 0;
-  --color-info-rgb: 21, 101, 192;
-  --color-success-rgb: 76, 175, 80;
+  --color-primary-rgb: 79, 70, 229;
+  --color-primary-hover-rgb: 129, 140, 248;
+  --color-sidebar-rgb: 30, 27, 75;
+  --color-secondary-rgb: 63, 63, 70;
+  --color-accent-rgb: 234, 179, 8;
+  --color-error-rgb: 220, 38, 38;
+  --color-warning-rgb: 217, 119, 6;
+  --color-info-rgb: 14, 165, 233;
+  --color-success-rgb: 5, 150, 105;
+  --color-ink-rgb: 24, 24, 27;
+
+  /* Elevation scale — single, restrained system */
+  --shadow-xs: 0 1px 2px rgba(24, 24, 27, 0.06);
+  --shadow-sm: 0 1px 3px rgba(24, 24, 27, 0.08), 0 1px 2px rgba(24, 24, 27, 0.04);
+  --shadow-md: 0 4px 12px rgba(24, 24, 27, 0.08);
+  --shadow-lg: 0 12px 28px rgba(24, 24, 27, 0.12);
+
+  /* Radii */
+  --radius-sm: 8px;
+  --radius-md: 10px;
+  --radius-lg: 12px;
+}
+
+/* ==========================================================================
+   Base typography — Plus Jakarta Sans (loaded in index.html)
+   ========================================================================== */
+html,
+body {
+  font-family: "Plus Jakarta Sans", system-ui, -apple-system, "Segoe UI",
+    sans-serif;
+  background-color: var(--color-surface);
+  color: var(--color-ink);
+}
+
+/* Apply across the whole Vuetify app and its component slots */
+.v-application,
+.v-application .text-h1,
+.v-application .text-h2,
+.v-application .text-h3,
+.v-application .text-h4,
+.v-application .text-h5,
+.v-application .text-h6,
+.v-application .text-subtitle-1,
+.v-application .text-subtitle-2,
+.v-application .text-body-1,
+.v-application .text-body-2,
+.v-application .text-button,
+.v-application .text-caption,
+.v-application .text-overline {
+  font-family: "Plus Jakarta Sans", system-ui, -apple-system, "Segoe UI",
+    sans-serif !important;
+}
+
+/* Page surface for the main content region */
+.v-main {
+  background-color: var(--color-surface);
+}
+
+/* Headings: tighten and firm up weight */
+.v-application .text-h3,
+.v-application .text-h4,
+.v-application .text-h5 {
+  font-weight: 800 !important;
+  letter-spacing: -0.02em;
+  color: var(--color-ink);
+}
+
+.v-application .text-h6 {
+  font-weight: 700 !important;
+  letter-spacing: -0.01em;
+  color: var(--color-ink);
+}
+
+/* Tabular figures for numeric data so columns/metrics don't shift */
+.tabular-nums,
+.kpi-value,
+.v-data-table td,
+.v-data-table th {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
+}
+
+/* Buttons: no shouty uppercase, slightly tighter */
+.v-btn {
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 600;
+}
+
+/* Respect reduced motion globally */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/client/src/styles/utilities.css
+++ b/client/src/styles/utilities.css
@@ -1,37 +1,44 @@
 /* Utility Classes and Layout Helpers */
 
-/* Page container styling */
+/* Page container padding */
 .analytics,
 .performance-reviews,
 .org-chart {
   padding: 8px;
 }
 
-/* Enhanced spacing */
+/* Spacing */
+.gap-2 {
+  gap: 8px;
+}
 .gap-3 {
   gap: 12px;
 }
+.gap-4 {
+  gap: 16px;
+}
 
-/* Empty state styling */
+/* Empty state */
 .empty-state {
   text-align: center;
-  padding: 16px 16px;
-  background: rgba(245, 247, 250, 0.5);
-  border-radius: 8px;
-  border: 2px dashed rgba(158, 158, 158, 0.3);
+  padding: 24px 16px;
+  background: var(--color-surface);
+  border-radius: var(--radius-sm);
+  border: 1px dashed var(--color-border);
+  color: var(--color-gray);
 }
 
 .empty-state .v-icon {
   opacity: 0.6;
 }
 
-/* Employee list styling */
+/* Scrollable employee list */
 .employee-list {
   max-height: 200px;
   overflow-y: auto;
 }
 
-/* Organization chart container */
+/* ----- Organization chart layout ----- */
 .org-chart-container {
   min-height: 400px;
   overflow-x: auto;
@@ -59,77 +66,91 @@
   min-width: fit-content;
 }
 
-/* Responsive adjustments */
 @media (min-width: 1200px) {
   .org-chart-container {
     padding: 40px;
   }
-
   .root-level {
     padding: 0 60px;
   }
 }
 
-/* Common color utilities */
+/* ----- Color text utilities ----- */
 .text-primary {
   color: var(--color-primary) !important;
 }
-
 .text-success {
   color: var(--color-success) !important;
 }
-
 .text-warning {
   color: var(--color-warning) !important;
 }
-
 .text-error {
   color: var(--color-error) !important;
 }
-
 .text-info {
   color: var(--color-info) !important;
 }
+.text-gold {
+  color: var(--color-accent-text) !important;
+}
+.text-ink {
+  color: var(--color-ink) !important;
+}
+.text-slate {
+  color: var(--color-slate) !important;
+}
+.text-muted {
+  color: var(--color-gray) !important;
+}
 
-/* Background utilities */
+/* Eyebrow / overline label (uppercase, gray, spaced) */
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  color: var(--color-gray);
+}
+
+/* ----- Background tints ----- */
 .bg-primary-light {
   background: rgba(var(--color-primary-rgb), 0.1) !important;
 }
-
+.bg-primary-pale {
+  background: var(--color-primary-pale) !important;
+}
+.bg-gold-pale {
+  background: var(--color-accent-pale) !important;
+}
 .bg-success-light {
-  background: rgba(var(--color-success-rgb), 0.1) !important;
+  background: rgba(var(--color-success-rgb), 0.12) !important;
 }
-
 .bg-warning-light {
-  background: rgba(var(--color-warning-rgb), 0.1) !important;
+  background: rgba(var(--color-warning-rgb), 0.12) !important;
 }
-
 .bg-error-light {
-  background: rgba(var(--color-error-rgb), 0.1) !important;
+  background: rgba(var(--color-error-rgb), 0.12) !important;
 }
 
-/* Shadow utilities */
+/* ----- Shadow utilities (single scale) ----- */
 .shadow-light {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-xs);
 }
-
 .shadow-medium {
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
 }
-
 .shadow-heavy {
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-lg);
 }
 
-/* Transition utilities */
+/* ----- Transitions ----- */
 .transition-all {
-  transition: all 0.3s ease;
-}
-
-.transition-fast {
   transition: all 0.2s ease;
 }
-
+.transition-fast {
+  transition: all 0.15s ease;
+}
 .transition-slow {
-  transition: all 0.5s ease;
+  transition: all 0.4s ease;
 }

--- a/client/src/views/Analytics.vue
+++ b/client/src/views/Analytics.vue
@@ -1,211 +1,193 @@
 <template>
   <div class="analytics">
-    <!-- Header Section -->
-    <v-card class="pa-4 ma-2 mb-4 header-card" elevation="3" rounded="lg">
-      <v-card-title class="pa-0 mb-2">
-        <h5 class="text-h5 text-primary font-weight-bold">
-          Employee Analytics Dashboard
-        </h5>
-      </v-card-title>
-      <v-card-subtitle class="pa-0">
-        <p class="text-body-2 text-medium-emphasis">
-          Comprehensive employee data analytics and insights
-        </p>
-      </v-card-subtitle>
-      <v-divider class="mt-4" />
-    </v-card>
+    <!-- Page header -->
+    <div class="page-head">
+      <span class="eyebrow">Overview</span>
+      <h1 class="page-title">Analytics</h1>
+      <p class="page-subtitle">
+        Comprehensive employee data analytics and insights.
+      </p>
+    </div>
 
     <!-- Loading State -->
     <div v-if="loading" class="text-center pa-8">
       <v-progress-circular
         indeterminate
         color="primary"
-        size="64"
+        size="56"
       ></v-progress-circular>
-      <p class="mt-4 text-body-1">Loading analytics data...</p>
+      <p class="mt-4 text-body-2 text-muted">Loading analytics data…</p>
     </div>
 
     <!-- Main Content -->
     <div v-else>
       <!-- Summary Cards -->
-      <v-row class="ma-n1">
+      <v-row>
         <v-col cols="12" sm="6" md="3">
-          <v-card
-            class="pa-4 summary-card"
-            elevation="3"
-            rounded="lg"
-            color="primary"
-            variant="tonal"
-          >
-            <div class="d-flex align-center">
-              <v-icon icon="mdi-account-group" size="40" class="mr-3"></v-icon>
-              <div>
-                <h3 class="text-h3">{{ analytics.totalEmployees }}</h3>
-                <p class="text-body-2">Total Employees</p>
-              </div>
+          <v-card class="kpi-card" flat>
+            <div class="kpi-icon">
+              <v-icon size="24">mdi-account-group</v-icon>
+            </div>
+            <div class="kpi-body">
+              <span class="kpi-label">Total Employees</span>
+              <span class="kpi-value tabular-nums">{{
+                analytics.totalEmployees
+              }}</span>
             </div>
           </v-card>
         </v-col>
         <v-col cols="12" sm="6" md="3">
-          <v-card
-            class="pa-4 summary-card"
-            elevation="3"
-            rounded="lg"
-            color="success"
-            variant="tonal"
-          >
-            <div class="d-flex align-center">
-              <v-icon icon="mdi-account-plus" size="40" class="mr-3"></v-icon>
-              <div>
-                <h3 class="text-h3">{{ analytics.activeEmployees }}</h3>
-                <p class="text-body-2">Active Employees</p>
-              </div>
+          <v-card class="kpi-card" flat>
+            <div class="kpi-icon kpi-icon--success">
+              <v-icon size="24">mdi-account-plus</v-icon>
+            </div>
+            <div class="kpi-body">
+              <span class="kpi-label">Active Employees</span>
+              <span class="kpi-value tabular-nums">{{
+                analytics.activeEmployees
+              }}</span>
             </div>
           </v-card>
         </v-col>
         <v-col cols="12" sm="6" md="3">
-          <v-card
-            class="pa-4 summary-card"
-            elevation="3"
-            rounded="lg"
-            color="info"
-            variant="tonal"
-          >
-            <div class="d-flex align-center">
-              <v-icon icon="mdi-domain" size="40" class="mr-3"></v-icon>
-              <div>
-                <h3 class="text-h3">{{ analytics.totalDepartments }}</h3>
-                <p class="text-body-2">Departments</p>
-              </div>
+          <v-card class="kpi-card" flat>
+            <div class="kpi-icon kpi-icon--info">
+              <v-icon size="24">mdi-domain</v-icon>
+            </div>
+            <div class="kpi-body">
+              <span class="kpi-label">Departments</span>
+              <span class="kpi-value tabular-nums">{{
+                analytics.totalDepartments
+              }}</span>
             </div>
           </v-card>
         </v-col>
         <v-col cols="12" sm="6" md="3">
-          <v-card
-            class="pa-4 summary-card"
-            elevation="3"
-            rounded="lg"
-            color="warning"
-            variant="tonal"
-          >
-            <div class="d-flex align-center">
-              <v-icon icon="mdi-currency-usd" size="40" class="mr-3"></v-icon>
-              <div>
-                <h3 class="text-h3">
-                  {{ Math.round(analytics.averageSalary).toLocaleString() }}
-                </h3>
-                <p class="text-body-2">Average Salary</p>
-              </div>
+          <v-card class="kpi-card kpi-card--gold" flat>
+            <div class="kpi-icon">
+              <v-icon size="24">mdi-currency-usd</v-icon>
+            </div>
+            <div class="kpi-body">
+              <span class="kpi-label">Average Salary</span>
+              <span class="kpi-value tabular-nums">
+                ${{ Math.round(analytics.averageSalary).toLocaleString() }}
+              </span>
             </div>
           </v-card>
         </v-col>
       </v-row>
 
       <!-- Charts Section Row 1 -->
-      <v-row class="ma-n1">
+      <v-row>
         <v-col cols="12" md="6">
-          <v-card class="pa-4 chart-card" elevation="3" rounded="lg">
-            <v-card-title class="pa-0 mb-3">
-              <h6 class="text-h6 text-primary font-weight-bold">
-                Department Distribution
-              </h6>
-            </v-card-title>
-            <div class="chart-container" style="height: 300px">
-              <DepartmentDistributionChart
-                :department-data="analytics.departmentDistribution"
-              />
+          <v-card class="chart-card" flat>
+            <div class="card-head">
+              <v-icon size="20">mdi-chart-donut</v-icon>
+              Department Distribution
+            </div>
+            <div class="pa-4">
+              <div class="chart-container" style="height: 300px">
+                <DepartmentDistributionChart
+                  :department-data="analytics.departmentDistribution"
+                />
+              </div>
             </div>
           </v-card>
         </v-col>
         <v-col cols="12" md="6">
-          <v-card class="pa-4 chart-card" elevation="3" rounded="lg">
-            <v-card-title class="pa-0 mb-3">
-              <h6 class="text-h6 text-primary font-weight-bold">
-                Employment Status
-              </h6>
-            </v-card-title>
-            <div class="chart-container" style="height: 300px">
-              <EmploymentStatusChart
-                :status-data="analytics.statusDistribution"
-              />
+          <v-card class="chart-card" flat>
+            <div class="card-head">
+              <v-icon size="20">mdi-chart-pie</v-icon>
+              Employment Status
+            </div>
+            <div class="pa-4">
+              <div class="chart-container" style="height: 300px">
+                <EmploymentStatusChart
+                  :status-data="analytics.statusDistribution"
+                />
+              </div>
             </div>
           </v-card>
         </v-col>
       </v-row>
 
       <!-- Charts Section Row 2 -->
-      <v-row class="ma-n1">
+      <v-row>
         <v-col cols="12" md="6">
-          <v-card class="pa-4 chart-card" elevation="3" rounded="lg">
-            <v-card-title class="pa-0 mb-3">
-              <h6 class="text-h6 text-primary font-weight-bold">
-                Salary Distribution by Department
-              </h6>
-            </v-card-title>
-            <div class="chart-container" style="height: 300px">
-              <SalaryDistributionChart
-                :salary-data="analytics.salaryByDepartment"
-              />
+          <v-card class="chart-card" flat>
+            <div class="card-head">
+              <v-icon size="20">mdi-chart-bar</v-icon>
+              Salary Distribution by Department
+            </div>
+            <div class="pa-4">
+              <div class="chart-container" style="height: 300px">
+                <SalaryDistributionChart
+                  :salary-data="analytics.salaryByDepartment"
+                />
+              </div>
             </div>
           </v-card>
         </v-col>
         <v-col cols="12" md="6">
-          <v-card class="pa-4 chart-card" elevation="3" rounded="lg">
-            <v-card-title class="pa-0 mb-3">
-              <h6 class="text-h6 text-primary font-weight-bold">
-                Job Level Distribution
-              </h6>
-            </v-card-title>
-            <div class="chart-container" style="height: 300px">
-              <JobLevelChart :job-level-data="analytics.jobLevelDistribution" />
+          <v-card class="chart-card" flat>
+            <div class="card-head">
+              <v-icon size="20">mdi-chart-arc</v-icon>
+              Job Level Distribution
+            </div>
+            <div class="pa-4">
+              <div class="chart-container" style="height: 300px">
+                <JobLevelChart
+                  :job-level-data="analytics.jobLevelDistribution"
+                />
+              </div>
             </div>
           </v-card>
         </v-col>
       </v-row>
 
       <!-- Charts Section Row 3 -->
-      <v-row class="ma-n1">
+      <v-row>
         <v-col cols="12">
-          <v-card class="pa-4 chart-card" elevation="3" rounded="lg">
-            <v-card-title class="pa-0 mb-3">
-              <h6 class="text-h6 text-primary font-weight-bold">
-                Hiring Trends (Last 12 Months)
-              </h6>
-            </v-card-title>
-            <div class="chart-container" style="height: 400px">
-              <HiringTrendsChart :hiring-data="analytics.hiringTrends" />
+          <v-card class="chart-card" flat>
+            <div class="card-head">
+              <v-icon size="20">mdi-chart-line</v-icon>
+              Hiring Trends — Last 12 Months
+            </div>
+            <div class="pa-4">
+              <div class="chart-container" style="height: 400px">
+                <HiringTrendsChart :hiring-data="analytics.hiringTrends" />
+              </div>
             </div>
           </v-card>
         </v-col>
       </v-row>
 
       <!-- Additional Analytics Cards -->
-      <v-row class="ma-n1">
+      <v-row>
         <v-col cols="12" md="4">
-          <v-card class="pa-4 info-card" elevation="3" rounded="lg">
-            <v-card-title class="pa-0 mb-3">
-              <h6 class="text-h6 text-primary font-weight-bold">
-                Recent Hires (30 Days)
-              </h6>
-            </v-card-title>
-            <v-list density="compact">
+          <v-card class="info-card" flat>
+            <div class="card-head">
+              <v-icon size="20">mdi-account-clock-outline</v-icon>
+              Recent Hires — 30 Days
+            </div>
+            <v-list density="compact" class="px-2 py-1">
               <v-list-item
                 v-for="hire in analytics.recentHires.slice(0, 5)"
                 :key="hire.id"
-                class="px-0"
+                class="stat-row"
               >
-                <v-list-item-title class="text-body-2">
+                <v-list-item-title class="stat-row-title">
                   {{ hire.name }}
                 </v-list-item-title>
-                <v-list-item-subtitle class="text-caption">
+                <v-list-item-subtitle class="stat-row-sub">
                   {{ hire.department }} • {{ hire.hireDate }}
                 </v-list-item-subtitle>
               </v-list-item>
               <v-list-item
                 v-if="analytics.recentHires.length === 0"
-                class="px-0"
+                class="stat-row"
               >
-                <v-list-item-title class="text-body-2 text-medium-emphasis">
+                <v-list-item-title class="text-muted">
                   No recent hires
                 </v-list-item-title>
               </v-list-item>
@@ -213,45 +195,43 @@
           </v-card>
         </v-col>
         <v-col cols="12" md="4">
-          <v-card class="pa-4 info-card" elevation="3" rounded="lg">
-            <v-card-title class="pa-0 mb-3">
-              <h6 class="text-h6 text-primary font-weight-bold">
-                Top Departments by Size
-              </h6>
-            </v-card-title>
-            <v-list density="compact">
+          <v-card class="info-card" flat>
+            <div class="card-head">
+              <v-icon size="20">mdi-trophy-outline</v-icon>
+              Top Departments by Size
+            </div>
+            <v-list density="compact" class="px-2 py-1">
               <v-list-item
                 v-for="dept in analytics.topDepartments"
                 :key="dept.name"
-                class="px-0"
+                class="stat-row"
               >
-                <v-list-item-title class="text-body-2">
+                <v-list-item-title class="stat-row-title">
                   {{ dept.name }}
                 </v-list-item-title>
-                <v-list-item-subtitle class="text-caption">
-                  {{ dept.count }} employees
-                </v-list-item-subtitle>
+                <template #append>
+                  <span class="stat-pill tabular-nums">{{ dept.count }}</span>
+                </template>
               </v-list-item>
             </v-list>
           </v-card>
         </v-col>
         <v-col cols="12" md="4">
-          <v-card class="pa-4 info-card" elevation="3" rounded="lg">
-            <v-card-title class="pa-0 mb-3">
-              <h6 class="text-h6 text-primary font-weight-bold">
-                Employment Types
-              </h6>
-            </v-card-title>
-            <v-list density="compact">
+          <v-card class="info-card" flat>
+            <div class="card-head">
+              <v-icon size="20">mdi-briefcase-outline</v-icon>
+              Employment Types
+            </div>
+            <v-list density="compact" class="px-2 py-1">
               <v-list-item
                 v-for="type in analytics.employmentTypes"
                 :key="type.type"
-                class="px-0"
+                class="stat-row"
               >
-                <v-list-item-title class="text-body-2">
+                <v-list-item-title class="stat-row-title">
                   {{ type.type }}
                 </v-list-item-title>
-                <v-list-item-subtitle class="text-caption">
+                <v-list-item-subtitle class="stat-row-sub">
                   {{ type.count }} employees ({{ type.percentage }}%)
                 </v-list-item-subtitle>
               </v-list-item>

--- a/client/src/views/EmployeeForm.vue
+++ b/client/src/views/EmployeeForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-card class="pa-4 ma-2 main-form-card" elevation="3" rounded="lg">
+    <v-card class="pa-4 main-form-card" flat rounded="lg">
       <!-- Header with navigation and actions -->
       <v-card-title
         class="py-3 d-flex justify-space-between align-center header-section"
@@ -13,7 +13,7 @@
             @click="backClicked"
             class="mr-2"
           />
-          <h5 class="text-h5 text-primary font-weight-bold">
+          <h5 class="text-h5 font-weight-bold text-ink">
             {{ pageTitle }}
           </h5>
         </div>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -1,122 +1,141 @@
 <template>
-  <v-container>
-    <!-- Welcome Header -->
-    <v-row class="mb-6">
-      <v-col cols="12">
-        <v-card class="pa-6 text-center" color="primary" dark>
-          <v-card-title class="text-h3 mb-2">
-            <v-icon size="large" class="mr-3">mdi-office-building</v-icon>
-            Welcome to Employee Management System
-          </v-card-title>
-          <v-card-subtitle class="text-h6">
-            Manage your workforce efficiently and effectively
-          </v-card-subtitle>
+  <v-container fluid class="pa-0">
+    <!-- Page header -->
+    <div class="page-head d-flex flex-wrap align-center justify-space-between">
+      <div>
+        <span class="eyebrow">Overview</span>
+        <h1 class="page-title">Dashboard</h1>
+        <p class="page-subtitle">
+          A live snapshot of your workforce and recent activity.
+        </p>
+      </div>
+      <v-btn
+        color="primary"
+        prepend-icon="mdi-account-plus-outline"
+        @click="$router.push('/employee/new')"
+      >
+        Add Employee
+      </v-btn>
+    </div>
+
+    <!-- KPI stats -->
+    <v-row class="mb-2">
+      <v-col cols="12" sm="6" md="3">
+        <v-card class="kpi-card kpi-card--gold" flat>
+          <div class="kpi-icon">
+            <v-icon size="24">mdi-account-multiple</v-icon>
+          </div>
+          <div class="kpi-body">
+            <span class="kpi-label">Total Employees</span>
+            <span class="kpi-value tabular-nums">{{ totalEmployees }}</span>
+          </div>
+        </v-card>
+      </v-col>
+      <v-col cols="12" sm="6" md="3">
+        <v-card class="kpi-card" flat>
+          <div class="kpi-icon kpi-icon--success">
+            <v-icon size="24">mdi-account-plus</v-icon>
+          </div>
+          <div class="kpi-body">
+            <span class="kpi-label">New Hires</span>
+            <span class="kpi-value tabular-nums">{{ newHires }}</span>
+            <span class="kpi-sub">Last 30 days</span>
+          </div>
+        </v-card>
+      </v-col>
+      <v-col cols="12" sm="6" md="3">
+        <v-card class="kpi-card" flat>
+          <div class="kpi-icon kpi-icon--info">
+            <v-icon size="24">mdi-domain</v-icon>
+          </div>
+          <div class="kpi-body">
+            <span class="kpi-label">Departments</span>
+            <span class="kpi-value tabular-nums">{{ totalDepartments }}</span>
+          </div>
+        </v-card>
+      </v-col>
+      <v-col cols="12" sm="6" md="3">
+        <v-card class="kpi-card" flat>
+          <div class="kpi-icon">
+            <v-icon size="24">mdi-chart-line</v-icon>
+          </div>
+          <div class="kpi-body">
+            <span class="kpi-label">Active Rate</span>
+            <span class="kpi-value tabular-nums">{{ activeRate }}%</span>
+          </div>
         </v-card>
       </v-col>
     </v-row>
 
-    <!-- Quick Stats -->
-    <v-row class="mb-6">
-      <v-col cols="12" sm="6" md="3">
-        <v-card class="text-center pa-4" elevation="2">
-          <v-icon size="x-large" color="primary" class="mb-2"
-            >mdi-account-multiple</v-icon
-          >
-          <h3 class="text-h4">{{ totalEmployees }}</h3>
-          <p class="text-subtitle1">Total Employees</p>
-        </v-card>
-      </v-col>
-      <v-col cols="12" sm="6" md="3">
-        <v-card class="text-center pa-4" elevation="2">
-          <v-icon size="x-large" color="success" class="mb-2"
-            >mdi-account-plus</v-icon
-          >
-          <h3 class="text-h4">{{ newHires }}</h3>
-          <p class="text-subtitle1">New Hires</p>
-        </v-card>
-      </v-col>
-      <v-col cols="12" sm="6" md="3">
-        <v-card class="text-center pa-4" elevation="2">
-          <v-icon size="x-large" color="warning" class="mb-2"
-            >mdi-domain</v-icon
-          >
-          <h3 class="text-h4">{{ totalDepartments }}</h3>
-          <p class="text-subtitle1">Departments</p>
-        </v-card>
-      </v-col>
-      <v-col cols="12" sm="6" md="3">
-        <v-card class="text-center pa-4" elevation="2">
-          <v-icon size="x-large" color="info" class="mb-2"
-            >mdi-chart-line</v-icon
-          >
-          <h3 class="text-h4">{{ activeRate }}%</h3>
-          <p class="text-subtitle1">Active Rate</p>
-        </v-card>
-      </v-col>
-    </v-row>
-
-    <!-- Quick Actions -->
+    <!-- Quick actions + recent activity -->
     <v-row>
-      <v-col cols="12" md="6">
-        <v-card class="pa-4" elevation="2">
-          <v-card-title>
-            <v-icon class="mr-2">mdi-lightning-bolt</v-icon>
+      <v-col cols="12" md="5">
+        <v-card class="info-card" flat>
+          <div class="card-head">
+            <v-icon size="20">mdi-lightning-bolt-outline</v-icon>
             Quick Actions
-          </v-card-title>
-          <v-card-text>
-            <v-btn
-              color="primary"
-              class="ma-2"
-              prepend-icon="mdi-account-plus"
-              variant="outlined"
-              @click="$router.push('/employee/new')"
-            >
-              Add New Employee
-            </v-btn>
-            <v-btn
-              color="secondary"
-              class="ma-2"
-              prepend-icon="mdi-file-document"
-              variant="outlined"
-              @click="handleGenerateReport"
-              :disabled="totalEmployees === 0"
-            >
-              Generate Report
-            </v-btn>
-            <v-btn
-              color="secondary"
-              class="ma-2"
-              prepend-icon="mdi-chart-box"
-              variant="outlined"
-              @click="$router.push('/analytics')"
-            >
-              View Analytics
-            </v-btn>
+          </div>
+          <v-card-text class="pa-4">
+            <div class="d-flex flex-column gap-3">
+              <v-btn
+                color="primary"
+                prepend-icon="mdi-account-plus-outline"
+                block
+                @click="$router.push('/employee/new')"
+              >
+                Add New Employee
+              </v-btn>
+              <v-btn
+                color="primary"
+                variant="outlined"
+                prepend-icon="mdi-chart-box-outline"
+                block
+                @click="$router.push('/analytics')"
+              >
+                View Analytics
+              </v-btn>
+              <v-btn
+                variant="outlined"
+                prepend-icon="mdi-file-download-outline"
+                block
+                @click="handleGenerateReport"
+                :disabled="totalEmployees === 0"
+              >
+                Generate Report
+              </v-btn>
+            </div>
           </v-card-text>
         </v-card>
       </v-col>
-      <v-col cols="12" md="6">
-        <v-card class="pa-4" elevation="2">
-          <v-card-title>
-            <v-icon class="mr-2">mdi-bell</v-icon>
+      <v-col cols="12" md="7">
+        <v-card class="info-card" flat>
+          <div class="card-head">
+            <v-icon size="20">mdi-bell-outline</v-icon>
             Recent Activity
-          </v-card-title>
-          <v-card-text>
-            <v-list v-if="recentActivities.length > 0" density="compact">
+          </div>
+          <v-card-text class="pa-2">
+            <v-list v-if="recentActivities.length > 0" class="activity-list">
               <v-list-item
                 v-for="activity in recentActivities"
                 :key="activity.id"
-                :prepend-icon="activity.icon"
+                class="activity-item"
               >
-                <v-list-item-title>{{ activity.title }}</v-list-item-title>
-                <v-list-item-subtitle>{{
+                <template #prepend>
+                  <div class="activity-icon">
+                    <v-icon size="18">{{ activity.icon }}</v-icon>
+                  </div>
+                </template>
+                <v-list-item-title class="activity-title">{{
+                  activity.title
+                }}</v-list-item-title>
+                <v-list-item-subtitle class="activity-time">{{
                   activity.relativeTime
                 }}</v-list-item-subtitle>
               </v-list-item>
             </v-list>
-            <div v-else class="text-center text-medium-emphasis pa-4">
-              <v-icon size="large" class="mb-2">mdi-information-outline</v-icon>
-              <p>No recent activity to display</p>
+            <div v-else class="empty-state ma-2">
+              <v-icon size="32" class="mb-2">mdi-information-outline</v-icon>
+              <p class="mb-0">No recent activity to display</p>
             </div>
           </v-card-text>
         </v-card>
@@ -254,4 +273,35 @@ const handleGenerateReport = () => {
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+.activity-list {
+  background: transparent;
+}
+.activity-item {
+  border-radius: var(--radius-sm);
+  margin-bottom: 2px;
+}
+.activity-item:hover {
+  background: var(--color-surface);
+}
+.activity-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  margin-right: 12px;
+  background: rgba(var(--color-primary-rgb), 0.1);
+  color: var(--color-primary);
+}
+.activity-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-ink);
+}
+.activity-time {
+  font-size: 0.75rem;
+  color: var(--color-gray);
+}
+</style>

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -1,116 +1,131 @@
 <template>
-  <v-container class="fill-height" fluid>
-    <v-row align="center" justify="center">
-      <v-col cols="12" sm="8" md="6" lg="4">
-        <v-card elevation="8" class="pa-4">
-          <v-card-title class="text-h4 text-center text-primary mb-4">
-            <v-icon
-              icon="mdi-account-circle"
-              size="large"
-              class="mr-2"
-              color="primary"
-            ></v-icon>
-            Login
-          </v-card-title>
+  <div class="auth-shell">
+    <!-- Brand panel -->
+    <aside class="auth-brand">
+      <div class="auth-brand-top">
+        <div class="auth-brand-tile">
+          <v-icon size="22" color="#EAB308">mdi-account-group</v-icon>
+        </div>
+        <div class="auth-brand-lockup">
+          <span class="auth-brand-name">EMS</span>
+          <span class="auth-brand-sub">Employee Console</span>
+        </div>
+      </div>
 
-          <v-card-text>
-            <v-alert
-              v-if="authStore.error"
-              type="error"
-              class="mb-4"
-              closable
-              @click:close="authStore.clearError()"
-            >
-              {{ authStore.error }}
-            </v-alert>
+      <div class="auth-brand-mid">
+        <h1 class="auth-headline">
+          Your workforce,<br />in one clear view.
+        </h1>
+        <p class="auth-subhead">
+          Hiring, performance, org structure, and reporting — managed from a
+          single enterprise console.
+        </p>
+        <ul class="auth-features">
+          <li>
+            <v-icon size="18" color="#818CF8">mdi-check-circle</v-icon>
+            Real-time headcount &amp; analytics
+          </li>
+          <li>
+            <v-icon size="18" color="#818CF8">mdi-check-circle</v-icon>
+            Performance review tracking
+          </li>
+          <li>
+            <v-icon size="18" color="#818CF8">mdi-check-circle</v-icon>
+            Org chart &amp; reporting lines
+          </li>
+        </ul>
+      </div>
 
-            <!-- Demo Credentials Info -->
-            <v-alert
-              type="info"
-              variant="tonal"
-              class="mb-6"
-              prominent
-              border="start"
-            >
-              <div class="d-flex align-center justify-space-between">
-                <div>
-                  <div class="text-subtitle-2 font-weight-bold mb-1">
-                    Demo Credentials
-                  </div>
-                  <div class="text-body-2">
-                    <strong>Email:</strong> test@example.com<br />
-                    <strong>Password:</strong> Test123!
-                  </div>
-                </div>
-                <v-btn
-                  color="info"
-                  variant="elevated"
-                  size="small"
-                  @click="fillDemoCredentials"
-                  class="ml-4"
-                >
-                  Use Demo
-                </v-btn>
-              </div>
-            </v-alert>
+      <div class="auth-brand-foot">
+        © {{ new Date().getFullYear() }} Employee Management System
+      </div>
+    </aside>
 
-            <v-form @submit.prevent="handleLogin">
-              <v-text-field
-                v-model="email"
-                label="Email"
-                type="email"
-                prepend-icon="mdi-email"
-                :error-messages="emailError"
-                required
-                variant="outlined"
-                class="mb-2"
-                color="primary"
-              ></v-text-field>
+    <!-- Form panel -->
+    <main class="auth-form-wrap">
+      <div class="auth-form">
+        <div class="auth-form-head">
+          <h2 class="auth-title">Sign in</h2>
+          <p class="auth-desc">Welcome back. Enter your credentials to continue.</p>
+        </div>
 
-              <v-text-field
-                v-model="password"
-                label="Password"
-                :type="showPassword ? 'text' : 'password'"
-                prepend-icon="mdi-lock"
-                :append-inner-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
-                @click:append-inner="showPassword = !showPassword"
-                :error-messages="passwordError"
-                required
-                variant="outlined"
-                class="mb-2"
-                color="primary"
-              ></v-text-field>
+        <v-alert
+          v-if="authStore.error"
+          type="error"
+          variant="tonal"
+          class="mb-4"
+          closable
+          @click:close="authStore.clearError()"
+        >
+          {{ authStore.error }}
+        </v-alert>
 
-              <v-btn
-                type="submit"
-                color="primary"
-                block
-                size="large"
-                :loading="authStore.isLoading"
-                class="mt-4"
-              >
-                Login
-              </v-btn>
-            </v-form>
-
-            <v-divider class="my-6"></v-divider>
-
-            <div class="text-center">
-              <p class="text-body-2">
-                Don't have an account?
-                <router-link
-                  to="/register"
-                  class="text-primary text-decoration-none"
-                >
-                  Register here
-                </router-link>
-              </p>
+        <!-- Demo Credentials Info -->
+        <div class="demo-box">
+          <div>
+            <div class="demo-title">Demo credentials</div>
+            <div class="demo-creds">
+              test@example.com&nbsp;·&nbsp;Test123!
             </div>
-          </v-card-text>
-        </v-card>
-      </v-col>
-    </v-row>
-  </v-container>
+          </div>
+          <v-btn
+            color="primary"
+            variant="tonal"
+            size="small"
+            @click="fillDemoCredentials"
+          >
+            Use demo
+          </v-btn>
+        </div>
+
+        <v-form @submit.prevent="handleLogin">
+          <v-text-field
+            v-model="email"
+            label="Email"
+            type="email"
+            prepend-inner-icon="mdi-email-outline"
+            :error-messages="emailError"
+            required
+            variant="outlined"
+            density="comfortable"
+            class="mb-3"
+            color="primary"
+          ></v-text-field>
+
+          <v-text-field
+            v-model="password"
+            label="Password"
+            :type="showPassword ? 'text' : 'password'"
+            prepend-inner-icon="mdi-lock-outline"
+            :append-inner-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+            @click:append-inner="showPassword = !showPassword"
+            :error-messages="passwordError"
+            required
+            variant="outlined"
+            density="comfortable"
+            class="mb-2"
+            color="primary"
+          ></v-text-field>
+
+          <v-btn
+            type="submit"
+            color="primary"
+            block
+            size="large"
+            :loading="authStore.isLoading"
+            class="mt-3"
+          >
+            Sign in
+          </v-btn>
+        </v-form>
+
+        <div class="auth-foot">
+          Don't have an account?
+          <router-link to="/register" class="auth-link">Create one</router-link>
+        </div>
+      </div>
+    </main>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -156,8 +171,4 @@ const handleLogin = handleSubmit(async (values) => {
 });
 </script>
 
-<style scoped>
-.v-card {
-  border-radius: 16px;
-}
-</style>
+<style scoped></style>

--- a/client/src/views/OrgChart.vue
+++ b/client/src/views/OrgChart.vue
@@ -1,107 +1,77 @@
 <template>
   <div class="org-chart">
-    <!-- Header Section -->
-    <v-card class="pa-4 ma-2 mb-4 header-card" elevation="3" rounded="lg">
-      <v-card-title class="pa-0 mb-2">
-        <h5 class="text-h5 text-primary font-weight-bold">
-          Organization Chart
-        </h5>
-      </v-card-title>
-      <v-card-subtitle class="pa-0">
-        <p class="text-body-2 text-medium-emphasis">
-          Hierarchical view of organizational structure and reporting
-          relationships
-        </p>
-      </v-card-subtitle>
-      <v-divider class="mt-4" />
-    </v-card>
+    <!-- Page header -->
+    <div class="page-head">
+      <span class="eyebrow">People</span>
+      <h1 class="page-title">Organization Chart</h1>
+      <p class="page-subtitle">
+        Hierarchical view of organizational structure and reporting
+        relationships.
+      </p>
+    </div>
 
     <!-- Loading State -->
     <div v-if="loading" class="text-center pa-8">
       <v-progress-circular
         indeterminate
         color="primary"
-        size="64"
+        size="56"
       ></v-progress-circular>
-      <p class="mt-4 text-body-1">Loading organization chart...</p>
+      <p class="mt-4 text-body-2 text-muted">Loading organization chart…</p>
     </div>
 
     <!-- Main Content -->
     <div v-else>
       <!-- Summary Cards -->
-      <v-row class="ma-n1 mb-4">
+      <v-row class="mb-2">
         <v-col cols="12" sm="6" md="3">
-          <v-card
-            class="pa-4 summary-card"
-            elevation="3"
-            rounded="lg"
-            color="primary"
-            variant="tonal"
-          >
-            <div class="d-flex align-center">
-              <v-icon icon="mdi-account-group" size="40" class="mr-3"></v-icon>
-              <div>
-                <h3 class="text-h3">{{ totalEmployees }}</h3>
-                <p class="text-body-2">Total Employees</p>
-              </div>
+          <v-card class="kpi-card" flat>
+            <div class="kpi-icon">
+              <v-icon size="24">mdi-account-group</v-icon>
+            </div>
+            <div class="kpi-body">
+              <span class="kpi-label">Total Employees</span>
+              <span class="kpi-value tabular-nums">{{ totalEmployees }}</span>
             </div>
           </v-card>
         </v-col>
         <v-col cols="12" sm="6" md="3">
-          <v-card
-            class="pa-4 summary-card"
-            elevation="3"
-            rounded="lg"
-            color="success"
-            variant="tonal"
-          >
-            <div class="d-flex align-center">
-              <v-icon icon="mdi-sitemap" size="40" class="mr-3"></v-icon>
-              <div>
-                <h3 class="text-h3">{{ maxLevels }}</h3>
-                <p class="text-body-2">Org Levels</p>
-              </div>
+          <v-card class="kpi-card" flat>
+            <div class="kpi-icon kpi-icon--success">
+              <v-icon size="24">mdi-sitemap-outline</v-icon>
+            </div>
+            <div class="kpi-body">
+              <span class="kpi-label">Org Levels</span>
+              <span class="kpi-value tabular-nums">{{ maxLevels }}</span>
             </div>
           </v-card>
         </v-col>
         <v-col cols="12" sm="6" md="3">
-          <v-card
-            class="pa-4 summary-card"
-            elevation="3"
-            rounded="lg"
-            color="info"
-            variant="tonal"
-          >
-            <div class="d-flex align-center">
-              <v-icon icon="mdi-account-tie" size="40" class="mr-3"></v-icon>
-              <div>
-                <h3 class="text-h3">{{ totalManagers }}</h3>
-                <p class="text-body-2">Managers</p>
-              </div>
+          <v-card class="kpi-card" flat>
+            <div class="kpi-icon kpi-icon--info">
+              <v-icon size="24">mdi-account-tie-outline</v-icon>
+            </div>
+            <div class="kpi-body">
+              <span class="kpi-label">Managers</span>
+              <span class="kpi-value tabular-nums">{{ totalManagers }}</span>
             </div>
           </v-card>
         </v-col>
         <v-col cols="12" sm="6" md="3">
-          <v-card
-            class="pa-4 summary-card"
-            elevation="3"
-            rounded="lg"
-            color="warning"
-            variant="tonal"
-          >
-            <div class="d-flex align-center">
-              <v-icon icon="mdi-domain" size="40" class="mr-3"></v-icon>
-              <div>
-                <h3 class="text-h3">{{ totalDepartments }}</h3>
-                <p class="text-body-2">Departments</p>
-              </div>
+          <v-card class="kpi-card" flat>
+            <div class="kpi-icon kpi-icon--warning">
+              <v-icon size="24">mdi-domain</v-icon>
+            </div>
+            <div class="kpi-body">
+              <span class="kpi-label">Departments</span>
+              <span class="kpi-value tabular-nums">{{ totalDepartments }}</span>
             </div>
           </v-card>
         </v-col>
       </v-row>
 
       <!-- Filters -->
-      <v-card class="pa-4 ma-2 mb-4 filters-card" elevation="3" rounded="lg">
+      <v-card class="pa-4 mb-4 filters-card" flat>
         <v-row>
           <v-col cols="12" md="4">
             <v-text-field
@@ -157,19 +127,16 @@
       </v-card>
 
       <!-- Organization Chart -->
-      <v-card class="pa-2 ma-2 chart-card" elevation="3" rounded="lg">
-        <v-card-title class="pa-0 mb-2">
-          <h5 class="text-h5 text-primary font-weight-bold">
-            Organizational Hierarchy
-          </h5>
-        </v-card-title>
+      <v-card class="chart-card" flat>
+        <div class="card-head">
+          <v-icon size="20">mdi-sitemap-outline</v-icon>
+          Organizational Hierarchy
+        </div>
 
         <div class="org-chart-container">
-          <div v-if="filteredOrgChart.length === 0" class="text-center pa-8">
-            <v-icon icon="mdi-account-search" size="64" color="grey"></v-icon>
-            <p class="text-body-1 mt-4">
-              No employees found matching your criteria
-            </p>
+          <div v-if="filteredOrgChart.length === 0" class="empty-state ma-4">
+            <v-icon icon="mdi-account-search-outline" size="40"></v-icon>
+            <p class="mt-2 mb-0">No employees found matching your criteria</p>
           </div>
           <div v-else class="org-hierarchy">
             <!-- Root level employees (CEO, top executives) -->

--- a/client/src/views/PerformanceReviews.vue
+++ b/client/src/views/PerformanceReviews.vue
@@ -1,104 +1,77 @@
 <template>
   <div class="performance-reviews">
-    <!-- Header Section -->
-    <v-card class="pa-4 ma-2 mb-4 header-card" elevation="3" rounded="lg">
-      <v-card-title class="pa-0 mb-2">
-        <h5 class="text-h5 text-primary font-weight-bold">
-          Performance Reviews Dashboard
-        </h5>
-      </v-card-title>
-      <v-card-subtitle class="pa-0">
-        <p class="text-body-2 text-medium-emphasis">
-          Comprehensive performance analytics and review management
-        </p>
-      </v-card-subtitle>
-      <v-divider class="mt-4" />
-    </v-card>
+    <!-- Page header -->
+    <div class="page-head">
+      <span class="eyebrow">Overview</span>
+      <h1 class="page-title">Performance Reviews</h1>
+      <p class="page-subtitle">
+        Performance analytics and review management across your organization.
+      </p>
+    </div>
 
     <!-- Loading State -->
     <div v-if="loading" class="text-center pa-8">
       <v-progress-circular
         indeterminate
         color="primary"
-        size="64"
+        size="56"
       ></v-progress-circular>
-      <p class="mt-4 text-body-1">Loading performance data...</p>
+      <p class="mt-4 text-body-2 text-muted">Loading performance data…</p>
     </div>
 
     <!-- Main Content -->
     <div v-else>
       <!-- Summary Cards -->
-      <v-row class="ma-n1">
+      <v-row>
         <v-col cols="12" sm="6" md="3">
-          <v-card
-            class="pa-4 summary-card"
-            elevation="3"
-            rounded="lg"
-            color="primary"
-            variant="tonal"
-          >
-            <div class="d-flex align-center">
-              <v-icon icon="mdi-chart-line" size="40" class="mr-3"></v-icon>
-              <div>
-                <h3 class="text-h3">{{ analytics.totalReviews }}</h3>
-                <p class="text-body-2">Total Reviews</p>
-              </div>
+          <v-card class="kpi-card" flat>
+            <div class="kpi-icon">
+              <v-icon size="24">mdi-chart-line</v-icon>
             </div>
-          </v-card>
-        </v-col>
-
-        <v-col cols="12" sm="6" md="3">
-          <v-card
-            class="pa-4 summary-card"
-            elevation="3"
-            rounded="lg"
-            color="success"
-            variant="tonal"
-          >
-            <div class="d-flex align-center">
-              <v-icon icon="mdi-star" size="40" class="mr-3"></v-icon>
-              <div>
-                <h3 class="text-h3">
-                  {{ analytics.averageRating.toFixed(1) }}
-                </h3>
-                <p class="text-body-2">Average Rating</p>
-              </div>
+            <div class="kpi-body">
+              <span class="kpi-label">Total Reviews</span>
+              <span class="kpi-value tabular-nums">{{
+                analytics.totalReviews
+              }}</span>
             </div>
           </v-card>
         </v-col>
         <v-col cols="12" sm="6" md="3">
-          <v-card
-            class="pa-4 summary-card"
-            elevation="3"
-            rounded="lg"
-            color="info"
-            variant="tonal"
-          >
-            <div class="d-flex align-center">
-              <v-icon icon="mdi-account-group" size="40" class="mr-3"></v-icon>
-              <div>
-                <h3 class="text-h3">
-                  {{ Object.keys(analytics.departmentPerformance).length }}
-                </h3>
-                <p class="text-body-2">Departments</p>
-              </div>
+          <v-card class="kpi-card kpi-card--gold" flat>
+            <div class="kpi-icon">
+              <v-icon size="24">mdi-star</v-icon>
+            </div>
+            <div class="kpi-body">
+              <span class="kpi-label">Average Rating</span>
+              <span class="kpi-value tabular-nums">{{
+                analytics.averageRating.toFixed(1)
+              }}</span>
             </div>
           </v-card>
         </v-col>
         <v-col cols="12" sm="6" md="3">
-          <v-card
-            class="pa-4 summary-card"
-            elevation="3"
-            rounded="lg"
-            color="warning"
-            variant="tonal"
-          >
-            <div class="d-flex align-center">
-              <v-icon icon="mdi-clock-alert" size="40" class="mr-3"></v-icon>
-              <div>
-                <h3 class="text-h3">{{ analytics.overdueReviews }}</h3>
-                <p class="text-body-2">Overdue Reviews</p>
-              </div>
+          <v-card class="kpi-card" flat>
+            <div class="kpi-icon kpi-icon--info">
+              <v-icon size="24">mdi-account-group</v-icon>
+            </div>
+            <div class="kpi-body">
+              <span class="kpi-label">Departments</span>
+              <span class="kpi-value tabular-nums">{{
+                Object.keys(analytics.departmentPerformance).length
+              }}</span>
+            </div>
+          </v-card>
+        </v-col>
+        <v-col cols="12" sm="6" md="3">
+          <v-card class="kpi-card" flat>
+            <div class="kpi-icon kpi-icon--error">
+              <v-icon size="24">mdi-clock-alert-outline</v-icon>
+            </div>
+            <div class="kpi-body">
+              <span class="kpi-label">Overdue Reviews</span>
+              <span class="kpi-value tabular-nums">{{
+                analytics.overdueReviews
+              }}</span>
             </div>
           </v-card>
         </v-col>
@@ -127,7 +100,7 @@
       </v-row>
 
       <!-- Filters and Search -->
-      <v-card class="pa-4 ma-2 mb-4 filters-card" elevation="3" rounded="lg">
+      <v-card class="pa-4 mb-4 filters-card" flat>
         <v-row>
           <v-col cols="12" md="4">
             <v-text-field
@@ -183,19 +156,17 @@
       </v-card>
 
       <!-- Review Status Table -->
-      <v-card class="pa-4 ma-2 table-card" elevation="3" rounded="lg">
-        <v-card-title class="pa-0 mb-2">
-          <h5 class="text-h5 text-primary font-weight-bold">
-            Employee Review Status
-          </h5>
-        </v-card-title>
-        <v-divider class="mb-4" />
+      <v-card class="table-card" flat>
+        <div class="card-head">
+          <v-icon size="20">mdi-clipboard-text-clock-outline</v-icon>
+          Employee Review Status
+        </div>
 
         <v-data-table
           :headers="tableHeaders"
           :items="filteredEmployees"
           density="compact"
-          class="elevation-0 rounded-lg performance-data-table"
+          class="elevation-0 performance-data-table px-2 pb-2"
           :items-per-page="15"
           :items-per-page-options="[10, 15, 25, 50]"
           :hide-default-footer="filteredEmployees.length < 11"
@@ -458,129 +429,8 @@ onMounted(() => {
 </script>
 
 <style scoped>
-/* Component-specific styles only - common styles are in global CSS */
-
-/* Search field enhancements */
-.search-field {
-  transition: all 0.3s ease;
-}
-
-.search-field :deep(.v-field__outline) {
-  --v-field-border-opacity: 0.3;
-}
-
-.search-field :deep(.v-field--focused .v-field__outline) {
-  --v-field-border-opacity: 1;
-  border-width: 2px;
-}
-
-.search-field :deep(.v-field__input) {
-  background: rgba(var(--color-primary-rgb), 0.02);
-  border-radius: 8px;
-}
-
-/* Filter field enhancements */
-.filter-field {
-  transition: all 0.3s ease;
-}
-
-.filter-field :deep(.v-field__outline) {
-  --v-field-border-opacity: 0.3;
-}
-
-.filter-field :deep(.v-field--focused .v-field__outline) {
-  --v-field-border-opacity: 1;
-  border-width: 2px;
-}
-
-/* Table styling */
+/* Component-specific styles only — common table/card styles live in global CSS */
 .performance-data-table {
   background: transparent;
-}
-
-/* Table headers with enhanced styling */
-.performance-data-table :deep(.v-data-table-header__content) {
-  font-weight: 700;
-  color: var(--color-secondary);
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  letter-spacing: 0.5px;
-}
-
-.performance-data-table :deep(.v-data-table__th) {
-  background: #f5f7fa !important;
-}
-
-/* Row hover effects */
-.performance-data-table :deep(.v-data-table__tr:hover) {
-  background: linear-gradient(
-    135deg,
-    rgba(var(--color-primary-rgb), 0.04) 0%,
-    rgba(var(--color-primary-rgb), 0.08) 100%
-  );
-  transform: scale(1.005);
-  transition: all 0.2s ease;
-}
-
-.performance-data-table :deep(.v-data-table__td) {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
-}
-
-/* Alternating row colors for better readability */
-.performance-data-table :deep(.v-data-table__tr:nth-child(even)) {
-  background: rgba(248, 250, 252, 0.5);
-}
-
-/* Footer styling */
-.performance-data-table :deep(.v-data-table-footer) {
-  background: linear-gradient(135deg, #f8fafc 0%, #e8f4fd 100%);
-  border-top: 1px solid rgba(var(--color-primary-rgb), 0.2);
-  border-radius: 0 0 12px 12px;
-}
-
-/* Pagination button styling */
-.performance-data-table :deep(.v-pagination__item) {
-  transition: all 0.3s ease;
-}
-
-.performance-data-table :deep(.v-pagination__item:hover) {
-  background: rgba(var(--color-primary-rgb), 0.1);
-  transform: scale(1.05);
-}
-
-.performance-data-table :deep(.v-pagination__item--is-active) {
-  background: linear-gradient(
-    135deg,
-    var(--color-primary) 0%,
-    var(--color-info) 100%
-  );
-  color: white;
-  box-shadow: 0 2px 8px rgba(var(--color-primary-rgb), 0.3);
-}
-
-/* Card styling with subtle gradient */
-.header-card,
-.filters-card,
-.table-card {
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  transition: all 0.3s ease;
-}
-
-.header-card:hover,
-.filters-card:hover,
-.table-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
-}
-
-/* Summary card enhancements */
-.summary-card {
-  transition: all 0.3s ease;
-}
-
-.summary-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.15);
 }
 </style>

--- a/client/src/views/Register.vue
+++ b/client/src/views/Register.vue
@@ -1,94 +1,128 @@
 <template>
-  <v-container class="fill-height" fluid>
-    <v-row align="center" justify="center">
-      <v-col cols="12" sm="8" md="6" lg="5">
-        <v-card elevation="8" class="pa-4">
-          <v-card-title class="text-h4 text-center text-primary mb-4">
-            <v-icon icon="mdi-account-plus" size="large" class="mr-2"></v-icon>
-            Register
-          </v-card-title>
+  <div class="auth-shell">
+    <!-- Brand panel -->
+    <aside class="auth-brand">
+      <div class="auth-brand-top">
+        <div class="auth-brand-tile">
+          <v-icon size="22" color="#EAB308">mdi-account-group</v-icon>
+        </div>
+        <div class="auth-brand-lockup">
+          <span class="auth-brand-name">EMS</span>
+          <span class="auth-brand-sub">Employee Console</span>
+        </div>
+      </div>
 
-          <v-card-text>
-            <v-alert
-              v-if="authStore.error"
-              type="error"
-              class="mb-4"
-              closable
-              @click:close="authStore.clearError()"
-            >
-              {{ authStore.error }}
-            </v-alert>
+      <div class="auth-brand-mid">
+        <h1 class="auth-headline">
+          Get started in<br />a few seconds.
+        </h1>
+        <p class="auth-subhead">
+          Create your account to manage employees, track performance, and see
+          your organization at a glance.
+        </p>
+        <ul class="auth-features">
+          <li>
+            <v-icon size="18" color="#818CF8">mdi-check-circle</v-icon>
+            Centralized employee records
+          </li>
+          <li>
+            <v-icon size="18" color="#818CF8">mdi-check-circle</v-icon>
+            Bulk actions &amp; smart segments
+          </li>
+          <li>
+            <v-icon size="18" color="#818CF8">mdi-check-circle</v-icon>
+            Insightful workforce analytics
+          </li>
+        </ul>
+      </div>
 
-            <v-form @submit.prevent="handleRegister">
-              <v-text-field
-                v-model="full_name"
-                label="Full Name"
-                prepend-icon="mdi-account"
-                :error-messages="fullNameError"
-                required
-                variant="outlined"
-                class="mb-2"
-                color="primary"
-              ></v-text-field>
+      <div class="auth-brand-foot">
+        © {{ new Date().getFullYear() }} Employee Management System
+      </div>
+    </aside>
 
-              <v-text-field
-                v-model="email"
-                label="Email"
-                type="email"
-                prepend-icon="mdi-email"
-                :error-messages="emailError"
-                required
-                variant="outlined"
-                class="mb-2"
-                color="primary"
-              ></v-text-field>
+    <!-- Form panel -->
+    <main class="auth-form-wrap">
+      <div class="auth-form">
+        <div class="auth-form-head">
+          <h2 class="auth-title">Create account</h2>
+          <p class="auth-desc">Set up your console access in one step.</p>
+        </div>
 
-              <v-text-field
-                v-model="password"
-                label="Password"
-                :type="showPassword ? 'text' : 'password'"
-                prepend-icon="mdi-lock"
-                :append-inner-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
-                @click:append-inner="showPassword = !showPassword"
-                :error-messages="passwordError"
-                required
-                variant="outlined"
-                class="mb-2"
-                hint="Must be at least 8 characters with uppercase, lowercase, and number"
-                persistent-hint
-                color="primary"
-              ></v-text-field>
+        <v-alert
+          v-if="authStore.error"
+          type="error"
+          variant="tonal"
+          class="mb-4"
+          closable
+          @click:close="authStore.clearError()"
+        >
+          {{ authStore.error }}
+        </v-alert>
 
-              <v-btn
-                type="submit"
-                color="primary"
-                block
-                size="large"
-                :loading="authStore.isLoading"
-                class="mt-6"
-              >
-                Register
-              </v-btn>
-            </v-form>
+        <v-form @submit.prevent="handleRegister">
+          <v-text-field
+            v-model="full_name"
+            label="Full Name"
+            prepend-inner-icon="mdi-account-outline"
+            :error-messages="fullNameError"
+            required
+            variant="outlined"
+            density="comfortable"
+            class="mb-3"
+            color="primary"
+          ></v-text-field>
 
-            <v-divider class="my-6"></v-divider>
+          <v-text-field
+            v-model="email"
+            label="Email"
+            type="email"
+            prepend-inner-icon="mdi-email-outline"
+            :error-messages="emailError"
+            required
+            variant="outlined"
+            density="comfortable"
+            class="mb-3"
+            color="primary"
+          ></v-text-field>
 
-            <div class="text-center">
-              <p class="text-body-2">
-                Already have an account?
-                <router-link
-                  to="/login"
-                  class="text-primary text-decoration-none"
-                >
-                  Login here
-                </router-link>
-              </p>
-            </div>
-          </v-card-text>
-        </v-card>
-      </v-col>
-    </v-row>
-  </v-container>
+          <v-text-field
+            v-model="password"
+            label="Password"
+            :type="showPassword ? 'text' : 'password'"
+            prepend-inner-icon="mdi-lock-outline"
+            :append-inner-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+            @click:append-inner="showPassword = !showPassword"
+            :error-messages="passwordError"
+            required
+            variant="outlined"
+            density="comfortable"
+            class="mb-1"
+            color="primary"
+          ></v-text-field>
+          <p class="auth-hint">
+            At least 8 characters with uppercase, lowercase, and a number.
+          </p>
+
+          <v-btn
+            type="submit"
+            color="primary"
+            block
+            size="large"
+            :loading="authStore.isLoading"
+            class="mt-3"
+          >
+            Create account
+          </v-btn>
+        </v-form>
+
+        <div class="auth-foot">
+          Already have an account?
+          <router-link to="/login" class="auth-link">Sign in</router-link>
+        </div>
+      </div>
+    </main>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -129,8 +163,4 @@ const handleRegister = handleSubmit(async (values) => {
 });
 </script>
 
-<style scoped>
-.v-card {
-  border-radius: 16px;
-}
-</style>
+<style scoped></style>

--- a/client/src/views/SearchEmployees.vue
+++ b/client/src/views/SearchEmployees.vue
@@ -1,17 +1,16 @@
 <template>
   <div>
-    <!-- Search Form Card -->
-    <v-card class="pa-4 ma-2 data-table-card" elevation="3" rounded="lg">
-      <v-card-title class="pa-0 mb-2">
-        <h5 class="text-h5 text-primary font-weight-bold">Search Employees</h5>
-      </v-card-title>
-      <v-card-subtitle class="pa-0 mb-4">
-        <p class="text-body-2 text-medium-emphasis">
-          Use the filters below to search for employees across all fields
-        </p>
-      </v-card-subtitle>
-      <v-divider class="mb-4" />
+    <!-- Page header -->
+    <div class="page-head">
+      <span class="eyebrow">People</span>
+      <h1 class="page-title">Search Employees</h1>
+      <p class="page-subtitle">
+        Use the filters below to search for employees across all fields.
+      </p>
+    </div>
 
+    <!-- Search Form Card -->
+    <v-card class="filters-card pa-5" flat>
       <!-- Search Form -->
       <v-form @submit.prevent="performSearch">
         <v-row>
@@ -173,18 +172,17 @@
     <!-- No Results Message -->
     <v-card
       v-if="hasSearched && searchResults.length === 0 && !searching"
-      class="pa-6 ma-2 text-center"
-      elevation="2"
-      rounded="lg"
+      class="pa-8 text-center info-card"
+      flat
     >
       <v-icon
-        icon="mdi-account-search"
-        size="64"
-        color="grey-lighten-1"
-        class="mb-4"
+        icon="mdi-account-search-outline"
+        size="48"
+        color="primary"
+        class="mb-3"
       />
-      <h6 class="text-h6 text-medium-emphasis mb-2">No employees found</h6>
-      <p class="text-body-2 text-medium-emphasis">
+      <h6 class="text-h6 mb-1">No employees found</h6>
+      <p class="text-body-2 text-muted mb-0">
         Try adjusting your search criteria or clearing some filters to see more
         results.
       </p>
@@ -356,42 +354,5 @@ onMounted(async () => {
 </script>
 
 <style scoped>
-/* Card styling with subtle gradient */
-.data-table-card {
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  transition: all 0.3s ease;
-}
-
-.data-table-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
-}
-
-/* Enhanced divider with gradient */
-
-/* Form field enhancements */
-::deep(.v-field__outline) {
-  --v-field-border-opacity: 0.3;
-}
-
-::deep(.v-field--focused .v-field__outline) {
-  --v-field-border-opacity: 1;
-  border-width: 2px;
-}
-
-::deep(.v-field__input) {
-  background: rgba(var(--color-primary-rgb), 0.02);
-  border-radius: 8px;
-}
-
-/* Button styling */
-.v-btn {
-  transition: all 0.3s ease;
-}
-
-.v-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-}
+/* Visuals handled by global CSS. */
 </style>

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,5 +1,9 @@
 /// <reference types="vite/client" />
 
+// Vuetify ships its base styles as a side-effect CSS entry (`import "vuetify/styles"`).
+// Declare it so `noUncheckedSideEffectImports` can resolve the module.
+declare module "vuetify/styles";
+
 declare module "*.vue" {
   import type { DefineComponent } from "vue";
   const component: DefineComponent<{}, {}, any>;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev:client": "cd client && npm run dev",
-    "dev:server": "cd server && uvicorn app.main:app --reload --host 0.0.0.0 --port 8000",
+    "dev:server": "cd server && python3 -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000",
     "dev": "concurrently \"npm run dev:client\" \"npm run dev:server\"",
     "build:client": "cd client && npm run build",
     "build": "npm run build:client"


### PR DESCRIPTION
🎨 Complete UI Redesign — Enterprise Console

Transforms the Employee Management System from a default Vuetify/Material look into a distinctive, professional **enterprise console** built around a custom indigo + gold design system. This is a frontend-only overhaul — no business logic, API, or data-model changes.

### Why

The previous UI used stock Material styling (teal primary, Roboto, gradient cards) that read as a generic starter. This redesign establishes a cohesive, polished visual language appropriate for an HR admin product, and intentionally distinct from other apps in the portfolio (it avoids dark mode, monospace type, and lime/teal accents).

### Design System

- **Palette:** indigo primary (`#4F46E5`), midnight-indigo sidebar (`#1E1B4B`), warm gold accent (`#EAB308` fills / `#A16207` text), light `#F4F4F5` surface, white cards. Tokens centralized in `client/src/styles/index.css` and `client/src/plugins/vuetify.ts`.
- **Typography:** Plus Jakarta Sans (loaded via Google Fonts), with tabular figures on all numeric/data columns.
- **Visual language:** flat, bordered cards with a single restrained elevation scale (no gradients or hover-lift), denser spacing, clear hierarchy via size/weight, status-badge color recipes, and a consistent KPI-card pattern.

### What Changed

**App shell (`App.vue`)**
- New persistent **midnight-indigo sidebar** with an "EMS / Employee Console" brand lockup.
- 13 flat nav links regrouped into **Overview / People / Segments / Pipeline** sections with a soft-violet active indicator.
- White top bar with current-page title and a user avatar chip; manual collapse toggle.

**Authentication (`Login.vue`, `Register.vue`)**
- Rebuilt as an enterprise **split-screen**: indigo brand panel (value props) + clean form panel on white.
- Fixed a bug where the empty top app bar painted over the login page (app bar is now fully auth-gated).

**Views**
- **Dashboard** — KPI stat cards, quick actions, recent-activity feed.
- **Analytics** & **Performance Reviews** — KPI cards, titled flat chart cards, cleaned-up data tables (gold reserved for the headline metric/rating).
- **Search**, **Employee Form**, **Org Chart** — moved to the shared page-header + flat-card system.

**Shared components & charts**
- Restyled `DataTable`, `AccordionTable`, `BulkActionsToolbar`, `BaseDialog`, `OrgChartNode`.
- All 8 Chart.js components updated to the new indigo→gold series palette inside flat chart cards.
- Consolidated a lot of duplicated per-component CSS into the global stylesheet system; added `client/src/styles/auth.css`.

### Responsive

- Tuned for **desktop and tablet** (mobile intentionally out of scope).
- Sidebar **auto-collapses to its icon rail below 1280px** (tablet/small laptop) and expands on desktop, with manual override preserved.
- KPI cards, charts, and filter rows reflow appropriately; data tables scroll within their own card rather than the page.

### Fixes (pre-existing, unrelated to the redesign)

- `vuetify/styles` type-resolution error — added `declare module "vuetify/styles"` (required by `noUncheckedSideEffectImports`).
- Unused-variable errors in `router/index.ts` and `EmploymentStatusChart.vue`.
- `npm run build` (typecheck + bundle) is now **green** end-to-end.

### Docs

- Updated `README.md`: "Mobile Friendly" → "Desktop & Tablet Optimized", "Material Design interface" → custom enterprise design system, org-chart responsiveness note, and corrected the backend JWT library (PyJWT → python-jose).

### Verification

- ✅ `npm run build` — clean typecheck (`vue-tsc -b`) + production bundle.
- ✅ Dev-server smoke test — serves 200, no runtime errors, fonts loading.
- ✅ Breakpoint audit across desktop/tablet for layout integrity and overflow.
- ⚠️ Not visually screenshotted in-tooling — recommend a quick manual pass at ~768px, ~1024px, and desktop widths.