### PR TITLE
Release - fix hierarchy, org chart, validations 

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -53,6 +53,7 @@ const navGroups = [
     items: [
       { title: "By Manager", icon: "mdi-account-tie-outline", to: "/by-manager" },
       { title: "By Department", icon: "mdi-domain", to: "/by-department" },
+      { title: "By Job Level", icon: "mdi-stairs", to: "/by-job-level" },
       { title: "By Status", icon: "mdi-account-switch-outline", to: "/by-status" },
       {
         title: "Contract Employees",
@@ -84,8 +85,13 @@ const navGroups = [
   },
 ];
 
-// Current page title for the top bar
-const pageTitle = computed(() => (route.name ? String(route.name) : "Dashboard"));
+// Current page title for the top bar — prefer the route's human-readable title
+// over its internal name (e.g. "Add Employee" instead of "employee-new").
+const pageTitle = computed(
+  () =>
+    (route.meta?.title as string | undefined) ??
+    (route.name ? String(route.name) : "Dashboard")
+);
 
 // Initials for the user avatar
 const userInitials = computed(() => {
@@ -272,12 +278,16 @@ watch(
           :model-value="initialLoading"
           class="align-center justify-center"
         >
-          <v-progress-circular
-            indeterminate
-            size="64"
-            color="primary"
-          ></v-progress-circular>
-          <div class="text-h6 mt-4">Loading Employee Management System...</div>
+          <div class="d-flex flex-column align-center text-center">
+            <v-progress-circular
+              indeterminate
+              size="64"
+              color="primary"
+            ></v-progress-circular>
+            <div class="text-h6 mt-4">
+              Loading Employee Management System...
+            </div>
+          </div>
         </v-overlay>
 
         <router-view v-if="!initialLoading" class="pa-4" />

--- a/client/src/components/AccordionTable.vue
+++ b/client/src/components/AccordionTable.vue
@@ -81,6 +81,7 @@ import type {
   ActionType,
 } from "../types";
 import DataTable from "./DataTable.vue";
+import { jobLevelRank } from "../constants/hierarchy";
 import { applyGroupTableFilter, exportToExcel } from "../modules/genericHelper";
 import BulkActionsToolbar from "./BulkActionsToolbar.vue";
 import { useDialogStore } from "../stores/dialog";
@@ -130,6 +131,7 @@ const computedHeaders = computed(() => {
     managerName: "Manager",
     department: "Department",
     status: "Status",
+    jobLevel: "Job Level",
     // Add more mappings as needed
   };
 
@@ -162,6 +164,14 @@ const groupedData = computed(() => {
     items,
     count: items.length,
   }));
+
+  // When grouping by job level, order the groups by seniority (CEO -> Entry)
+  // instead of arbitrary insertion order.
+  if (groupByInfo.value.groupBy === "jobLevel") {
+    assignedData = assignedData.sort(
+      (a, b) => jobLevelRank(b.groupedBy) - jobLevelRank(a.groupedBy)
+    );
+  }
   return assignedData;
 });
 

--- a/client/src/components/DataTable.vue
+++ b/client/src/components/DataTable.vue
@@ -64,6 +64,7 @@
 import { toRefs, ref, computed, watch } from "vue";
 import { useRouter } from "vue-router";
 import type { Employee, ActionType } from "../types";
+import { bySeniorityDesc } from "../constants/hierarchy";
 import { useDialogStore } from "../stores/dialog";
 import BulkActionsToolbar from "./BulkActionsToolbar.vue";
 import { useAppStore } from "../stores/app";
@@ -147,13 +148,17 @@ const selectedItems = computed<Employee[]>({
 });
 
 const filteredItems = computed(() => {
+  // Baseline ordering: most senior first (CEO -> Entry), consistent with the
+  // org chart. The data table's own column sorting overrides this on click.
+  const base = [...items.value].sort(bySeniorityDesc);
+
   if (!search.value) {
-    return items.value;
+    return base;
   }
 
   const searchTerm = search.value.trim().toLowerCase();
 
-  return items.value.filter((item) => {
+  return base.filter((item) => {
     // Only search in the columns specified by tableColumns prop
     return tableColumns.value.some((column) => {
       const value = item[column as keyof Employee];

--- a/client/src/components/OrgChartNode.vue
+++ b/client/src/components/OrgChartNode.vue
@@ -7,6 +7,7 @@
         highlighted: isHighlighted,
         'no-top-line': level === 0,
         'has-children': hasChildren,
+        executive: isExecutive,
       }"
       elevation="4"
       rounded="lg"
@@ -25,9 +26,16 @@
           </v-avatar>
           <div class="flex-grow-1">
             <h6
-              class="text-body-2 font-weight-bold text-primary mb-0 text-truncate"
+              class="text-body-2 font-weight-bold text-primary mb-0 text-truncate d-flex align-center"
             >
-              {{ employee.fullName }}
+              <v-icon
+                v-if="isExecutive"
+                :icon="executiveIcon"
+                size="14"
+                color="#A16207"
+                class="mr-1 flex-shrink-0"
+              />
+              <span class="text-truncate">{{ employee.fullName }}</span>
             </h6>
             <!-- <p class="text-caption text-medium-emphasis mb-0 text-truncate">
               {{ employee.position }}
@@ -79,14 +87,29 @@
             {{ employee.jobLevel }}
           </v-chip>
           <v-chip
+            v-if="hasChildren"
             color="primary"
             size="x-small"
             variant="tonal"
-            class="text-caption ml-1"
-            prepend-icon="mdi-account-multiple-outline"
+            class="text-caption ml-1 toggle-chip"
+            :prepend-icon="isExpanded ? 'mdi-chevron-down' : 'mdi-chevron-right'"
+            :title="`${isExpanded ? 'Collapse' : 'Expand'} ${
+              children.length
+            } direct report${children.length === 1 ? '' : 's'}`"
+            @click.stop="toggle"
           >
             {{ children.length }}
           </v-chip>
+          <v-btn
+            v-if="hasChildren"
+            icon="mdi-target"
+            size="x-small"
+            variant="text"
+            color="primary"
+            class="ml-1 focus-btn"
+            title="Focus on this team"
+            @click.stop="focus"
+          />
         </div>
       </v-card-text>
 
@@ -107,7 +130,7 @@
 
     <!-- Children -->
     <div
-      v-if="hasChildren"
+      v-if="hasChildren && isExpanded"
       class="children-container"
       ref="childrenContainerRef"
     >
@@ -152,9 +175,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted, onUnmounted, nextTick, watch } from "vue";
+import { computed, inject, ref, onMounted, onUnmounted, nextTick, watch } from "vue";
 import dayjs from "dayjs";
 import type { Employee, JobLevel } from "../types";
+import { ORG_CHART_API } from "../constants/orgChart";
 
 interface Props {
   employee: Employee & { children?: Employee[] };
@@ -175,9 +199,34 @@ defineEmits<Emits>();
 // Reactive data
 const showOverlay = ref(false);
 
+// Collapse/focus API provided by the OrgChart view (null-safe if used standalone).
+const org = inject(ORG_CHART_API, null);
+
 // Computed properties
 const children = computed(() => props.employee.children || []);
 const hasChildren = computed(() => children.value.length > 0);
+
+const isExpanded = computed(() => {
+  const id = props.employee._id;
+  if (!org || !id) return true;
+  return !org.isCollapsed(id);
+});
+
+const toggle = () => {
+  if (org && props.employee._id) org.toggleCollapsed(props.employee._id);
+};
+const focus = () => {
+  if (org && props.employee._id) org.focusNode(props.employee._id);
+};
+
+// Executives (CEO / C-Level) get a distinct marker in the chart.
+const isExecutive = computed(
+  () =>
+    props.employee.jobLevel === "CEO" || props.employee.jobLevel === "C-Level"
+);
+const executiveIcon = computed(() =>
+  props.employee.jobLevel === "CEO" ? "mdi-crown" : "mdi-star-circle"
+);
 
 const isHighlighted = computed(() => {
   if (!props.searchQuery) return false;
@@ -217,44 +266,54 @@ const setChildRef = (el: any, index: number) => {
 };
 
 const computeHorizontalLine = () => {
-  if (
-    !childrenContainerRef.value ||
-    childRefs.value.filter(Boolean).length < 2
-  ) {
+  const wrappers = childRefs.value.filter(Boolean);
+  if (!childrenContainerRef.value || wrappers.length < 2) {
     horizontalLineLeft.value = 0;
     horizontalLineWidth.value = 0;
     return;
   }
-  const containerRect = childrenContainerRef.value.getBoundingClientRect();
-  const centers = childRefs.value
-    .filter(Boolean)
-    .map((el) => {
-      const r = el.getBoundingClientRect();
-      return r.left - containerRect.left + r.width / 2;
-    })
+  // Use layout offsets, not getBoundingClientRect: offsetLeft/offsetWidth are in
+  // layout pixels relative to .children-container (the positioned ancestor the
+  // connector line also anchors to), so they're immune to CSS `zoom` and scroll
+  // and stay aligned at any zoom level.
+  const centers = wrappers
+    .map((el) => el.offsetLeft + el.offsetWidth / 2)
     .sort((a, b) => a - b);
-  if (centers.length < 2) {
-    horizontalLineLeft.value = 0;
-    horizontalLineWidth.value = 0;
-    return;
+  horizontalLineLeft.value = centers[0];
+  horizontalLineWidth.value = centers[centers.length - 1] - centers[0];
+};
+
+// Recompute on any layout change in this node's children row. Expanding a deeper
+// node widens its column, which resizes this row and shifts siblings — the
+// observer catches that and re-measures, so the connector lines stay aligned.
+let resizeObserver: ResizeObserver | null = null;
+const observeGrid = (el: HTMLElement | null) => {
+  resizeObserver?.disconnect();
+  if (el && typeof ResizeObserver !== "undefined") {
+    resizeObserver = new ResizeObserver(() =>
+      requestAnimationFrame(computeHorizontalLine)
+    );
+    resizeObserver.observe(el);
   }
-  // Start slightly to the left of the first child center and end slightly to the right of the last child center
-  const halfStub = 0; // stubs are centered on cards, no extra padding needed
-  horizontalLineLeft.value = centers[0] - halfStub;
-  horizontalLineWidth.value =
-    centers[centers.length - 1] - centers[0] + halfStub * 2;
 };
 
 onMounted(() => {
-  nextTick(() => computeHorizontalLine());
+  nextTick(() => {
+    computeHorizontalLine();
+    observeGrid(childrenGridRef.value);
+  });
   window.addEventListener("resize", computeHorizontalLine);
 });
 
 onUnmounted(() => {
   window.removeEventListener("resize", computeHorizontalLine);
+  resizeObserver?.disconnect();
 });
 
-watch(children, async () => {
+// Re-attach the observer whenever the children row mounts/unmounts (it's v-if'd).
+watch(childrenGridRef, (el) => observeGrid(el));
+
+watch([children, isExpanded], async () => {
   await nextTick();
   computeHorizontalLine();
 });
@@ -342,6 +401,12 @@ const getJobLevelColor = (jobLevel: JobLevel): string => {
   border-color: var(--color-primary);
   background: var(--color-primary-pale);
   box-shadow: 0 0 0 1px var(--color-primary), var(--shadow-sm);
+}
+
+/* Executives (CEO / C-Level): subtle gold ring to match the enterprise theme */
+.employee-card.executive {
+  border-color: #d4a82a;
+  box-shadow: 0 0 0 1px #d4a82a, var(--shadow-sm);
 }
 
 .employee-avatar {
@@ -515,6 +580,20 @@ const getJobLevelColor = (jobLevel: JobLevel): string => {
 ::deep(.v-chip) {
   font-weight: 600;
   letter-spacing: 0.5px;
+}
+
+/* Collapse toggle chip reads as interactive */
+.toggle-chip {
+  cursor: pointer;
+}
+.toggle-chip:hover {
+  filter: brightness(0.95);
+}
+.focus-btn {
+  opacity: 0.55;
+}
+.focus-btn:hover {
+  opacity: 1;
 }
 
 /* Icon styling */

--- a/client/src/components/baseDialog/dialogContent/AssignManager.vue
+++ b/client/src/components/baseDialog/dialogContent/AssignManager.vue
@@ -4,82 +4,87 @@
 
     <!-- Manager Assignment Form -->
     <v-form>
-      <v-card variant="outlined" class="section-card">
-        <v-card-title class="text-subtitle-1 section-header py-2">
-          <v-icon class="mr-2" size="small">mdi-account-tie</v-icon>
-          Manager Assignment
-        </v-card-title>
-        <v-card-text class="pa-3">
-          <v-row dense>
-            <v-col cols="12">
-              <v-select
-                v-model="selectedManagerId"
-                :items="managerOptions"
-                label="Select Manager *"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.managerId"
-                class="form-field"
-                color="primary"
-                item-title="title"
-                item-value="value"
-                clearable
-                :hint="
-                  selectedManagerId
-                    ? `Manager: ${getSelectedManagerInfo()}`
-                    : 'Choose a manager to assign to selected employees'
-                "
-                persistent-hint
-              >
-                <template v-slot:item="{ props }">
-                  <v-list-item v-bind="props">
-                    <template v-slot:prepend>
-                      <v-avatar size="32" color="primary">
-                        <v-icon icon="mdi-account-tie" />
-                      </v-avatar>
-                    </template>
-                  </v-list-item>
+      <v-row dense>
+        <v-col cols="12">
+          <v-select
+            v-model="selectedManagerId"
+            :items="managerOptions"
+            label="Select Manager *"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.managerId"
+            class="form-field"
+            color="primary"
+            item-title="title"
+            item-value="value"
+            clearable
+            no-data-text="No eligible managers for the selected employees' level"
+            :hint="
+              selectedManagerId
+                ? `Manager: ${getSelectedManagerInfo()}`
+                : managerOptions.length === 0
+                ? 'No eligible managers — a manager must be at or above the most senior selected employee'
+                : 'Choose a manager to assign to selected employees'
+            "
+            persistent-hint
+          >
+            <template v-slot:item="{ props }">
+              <v-list-item v-bind="props">
+                <template v-slot:prepend>
+                  <v-avatar size="32" color="primary">
+                    <v-icon icon="mdi-account-tie" />
+                  </v-avatar>
                 </template>
-              </v-select>
-            </v-col>
-            <v-col cols="12">
-              <v-textarea
-                v-model="assignmentNotes"
-                label="Assignment Notes"
-                variant="outlined"
-                rows="3"
-                density="compact"
-                :error-messages="errors.assignmentNotes"
-                class="form-field"
-                color="primary"
-                hint="Optional notes about this manager assignment"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12">
-              <v-text-field
-                v-model="effectiveDate"
-                label="Effective Date *"
-                type="date"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.effectiveDate"
-                class="form-field"
-                color="primary"
-                hint="Date when the manager assignment becomes effective"
-                persistent-hint
-              />
-            </v-col>
-          </v-row>
-        </v-card-text>
-      </v-card>
+              </v-list-item>
+            </template>
+          </v-select>
+        </v-col>
+        <v-col cols="12" v-if="selectedManagerId && skippedCount > 0">
+          <v-alert
+            :type="allSkipped ? 'warning' : 'info'"
+            variant="tonal"
+            density="compact"
+            class="text-caption"
+          >
+            {{ skippedCount }} selected employee(s) already report to this
+            manager and will be skipped.
+          </v-alert>
+        </v-col>
+        <v-col cols="12">
+          <v-textarea
+            v-model="assignmentNotes"
+            label="Assignment Notes"
+            variant="outlined"
+            rows="3"
+            density="comfortable"
+            :error-messages="errors.assignmentNotes"
+            class="form-field"
+            color="primary"
+            hint="Optional notes about this manager assignment"
+          />
+        </v-col>
+        <v-col cols="12">
+          <v-text-field
+            v-model="effectiveDate"
+            label="Effective Date *"
+            type="date"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.effectiveDate"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+      </v-row>
 
       <!-- Action Buttons -->
       <DialogActions
         :loading="isAssigning"
-        :disabled="!selectedManagerId || selectedEmployees.length === 0"
+        :disabled="
+          !selectedManagerId || selectedEmployees.length === 0 || allSkipped
+        "
         submit-text="Assign Manager"
         submit-icon="mdi-account-plus"
         :on-cancel="() => dialogStore.closeAndResetDialog()"
@@ -97,6 +102,7 @@ import { useDialogStore } from "../../../stores/dialog";
 import { useAppStore } from "../../../stores/app";
 import { useNotificationStore } from "../../../stores/notification";
 import type { Manager } from "../../../types";
+import { getEligibleManagers } from "../../../constants/hierarchy";
 import {
   assignManagerSchema,
   type AssignManagerFormData,
@@ -104,6 +110,7 @@ import {
 import SelectedEmployeesSummary from "./SelectedEmployeesSummary.vue";
 import DialogActions from "./DialogActions.vue";
 import { useBulkDialogForm } from "../../../composables/useBulkDialogForm";
+import { useApplicableEmployees } from "../../../composables/useApplicableEmployees";
 
 const dialogStore = useDialogStore();
 const appStore = useAppStore();
@@ -130,8 +137,25 @@ const [effectiveDate] = defineField("effectiveDate");
 // State
 const isAssigning = ref(false);
 
+// Skip employees already reporting to the chosen manager — re-assigning them is
+// a no-op that would only churn their manager-assignment date.
+const { applicableIds, skippedCount, allSkipped } = useApplicableEmployees(
+  selectedEmployees,
+  (emp) => emp.managerId !== selectedManagerId.value
+);
+
+// Only managers who may actually manage the selected employees (rank >= the
+// most senior selected employee, Active/On Leave, Full-time/Part-time, no cycles).
+const eligibleManagers = computed(() =>
+  getEligibleManagers({
+    reports: selectedEmployees.value,
+    managers: appStore.managers,
+    employees: appStore.employees,
+  })
+);
+
 const managerOptions = computed(() =>
-  appStore.managers.map((manager: Manager) => ({
+  eligibleManagers.value.map((manager: Manager) => ({
     title: manager.name,
     value: manager.id,
     subtitle: `${manager.department} - ${manager.email}`,
@@ -178,10 +202,15 @@ const assignManager = async () => {
       return;
     }
 
-    // Use the bulk assign method from the store
-    const employeeIds = selectedEmployees.value
-      .map((emp) => emp._id)
-      .filter((id) => id) as string[];
+    // Only assign employees not already reporting to this manager.
+    const employeeIds = applicableIds.value;
+    if (employeeIds.length === 0) {
+      notificationStore.showWarning(
+        "All selected employees already report to this manager."
+      );
+      isAssigning.value = false;
+      return;
+    }
     await appStore.bulkAssignManager(
       employeeIds,
       selectedManager.id,
@@ -191,7 +220,7 @@ const assignManager = async () => {
 
     // Show success message
     notificationStore.showSuccess(
-      `Successfully assigned ${selectedEmployees.value.length} employee(s) to ${selectedManager.name}`
+      `Successfully assigned ${employeeIds.length} employee(s) to ${selectedManager.name}`
     );
 
     // Close the dialog and reset form

--- a/client/src/components/baseDialog/dialogContent/ConductReview.vue
+++ b/client/src/components/baseDialog/dialogContent/ConductReview.vue
@@ -4,13 +4,8 @@
 
     <!-- Performance Review Form -->
     <v-form>
-      <v-card variant="outlined" class="section-card">
-        <v-card-title class="text-subtitle-1 section-header py-2">
-          <v-icon class="mr-2" size="small">mdi-star-circle</v-icon>
-          Performance Assessment
-        </v-card-title>
-        <v-card-text class="pa-3">
-          <v-row dense>
+      <div class="dialog-subhead">Performance Assessment</div>
+      <v-row dense>
             <v-col cols="12">
               <v-select
                 v-model="performanceRating"
@@ -37,16 +32,9 @@
               </v-select>
             </v-col>
           </v-row>
-        </v-card-text>
-      </v-card>
 
-      <v-card variant="outlined" class="section-card">
-        <v-card-title class="text-subtitle-1 section-header py-2">
-          <v-icon class="mr-2" size="small">mdi-calendar-range</v-icon>
-          Review Period
-        </v-card-title>
-        <v-card-text class="pa-3">
-          <v-row dense>
+      <div class="dialog-subhead">Review Period</div>
+      <v-row dense>
             <v-col cols="12" md="6">
               <v-text-field
                 v-model="reviewPeriodStart"
@@ -93,16 +81,9 @@
               />
             </v-col>
           </v-row>
-        </v-card-text>
-      </v-card>
 
-      <v-card variant="outlined" class="section-card">
-        <v-card-title class="text-subtitle-1 section-header py-2">
-          <v-icon class="mr-2" size="small">mdi-trophy</v-icon>
-          Achievements & Strengths
-        </v-card-title>
-        <v-card-text class="pa-3">
-          <v-row dense>
+      <div class="dialog-subhead">Achievements &amp; Strengths</div>
+      <v-row dense>
             <v-col cols="12">
               <v-textarea
                 v-model="achievements"
@@ -132,16 +113,9 @@
               />
             </v-col>
           </v-row>
-        </v-card-text>
-      </v-card>
 
-      <v-card variant="outlined" class="section-card">
-        <v-card-title class="text-subtitle-1 section-header py-2">
-          <v-icon class="mr-2" size="small">mdi-trending-up</v-icon>
-          Development & Improvement
-        </v-card-title>
-        <v-card-text class="pa-3">
-          <v-row dense>
+      <div class="dialog-subhead">Development &amp; Improvement</div>
+      <v-row dense>
             <v-col cols="12">
               <v-textarea
                 v-model="areasForImprovement"
@@ -171,16 +145,9 @@
               />
             </v-col>
           </v-row>
-        </v-card-text>
-      </v-card>
 
-      <v-card variant="outlined" class="section-card">
-        <v-card-title class="text-subtitle-1 section-header py-2">
-          <v-icon class="mr-2" size="small">mdi-comment-text</v-icon>
-          Additional Comments
-        </v-card-title>
-        <v-card-text class="pa-3">
-          <v-row dense>
+      <div class="dialog-subhead">Additional Comments</div>
+      <v-row dense>
             <v-col cols="12">
               <v-textarea
                 v-model="managerFeedback"
@@ -210,8 +177,6 @@
               />
             </v-col>
           </v-row>
-        </v-card-text>
-      </v-card>
 
       <!-- Action Buttons -->
       <DialogActions

--- a/client/src/components/baseDialog/dialogContent/ConvertEmployeeType.vue
+++ b/client/src/components/baseDialog/dialogContent/ConvertEmployeeType.vue
@@ -4,80 +4,85 @@
 
     <!-- Employment Type Conversion Form -->
     <v-form>
-      <v-card variant="outlined" class="section-card">
-        <v-card-title class="text-subtitle-1 section-header py-2">
-          <v-icon class="mr-2" size="small">mdi-account-convert</v-icon>
-          Employment Type Conversion
-        </v-card-title>
-        <v-card-text class="pa-3">
-          <v-row dense>
-            <v-col cols="12">
-              <v-select
-                v-model="selectedEmploymentType"
-                :items="appStore.formOptions.employmentTypes as string[]"
-                label="New Employment Type *"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.employmentType"
-                class="form-field"
-                color="primary"
-                clearable
-                :hint="
-                  selectedEmploymentType
-                    ? `Converting to: ${selectedEmploymentType}`
-                    : 'Choose the new employment type for selected employees'
-                "
-                persistent-hint
-              >
-                <template v-slot:item="{ props }">
-                  <v-list-item v-bind="props">
-                    <template v-slot:prepend>
-                      <v-avatar size="32" color="primary">
-                        <v-icon icon="mdi-account-convert" />
-                      </v-avatar>
-                    </template>
-                  </v-list-item>
+      <v-row dense>
+        <v-col cols="12">
+          <v-select
+            v-model="selectedEmploymentType"
+            :items="appStore.formOptions.employmentTypes as string[]"
+            label="New Employment Type *"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.employmentType"
+            class="form-field"
+            color="primary"
+            clearable
+            :hint="
+              selectedEmploymentType
+                ? `Converting to: ${selectedEmploymentType}`
+                : 'Choose the new employment type for selected employees'
+            "
+            persistent-hint
+          >
+            <template v-slot:item="{ props }">
+              <v-list-item v-bind="props">
+                <template v-slot:prepend>
+                  <v-avatar size="32" color="primary">
+                    <v-icon icon="mdi-account-convert" />
+                  </v-avatar>
                 </template>
-              </v-select>
-            </v-col>
-            <v-col cols="12">
-              <v-textarea
-                v-model="conversionNotes"
-                label="Conversion Notes"
-                variant="outlined"
-                rows="3"
-                density="compact"
-                :error-messages="errors.conversionNotes"
-                class="form-field"
-                color="primary"
-                hint="Optional notes about this employment type conversion"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12">
-              <v-text-field
-                v-model="effectiveDate"
-                label="Effective Date *"
-                type="date"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.effectiveDate"
-                class="form-field"
-                color="primary"
-                hint="Date when the employment type change becomes effective"
-                persistent-hint
-              />
-            </v-col>
-          </v-row>
-        </v-card-text>
-      </v-card>
+              </v-list-item>
+            </template>
+          </v-select>
+        </v-col>
+        <v-col cols="12" v-if="selectedEmploymentType && skippedCount > 0">
+          <v-alert
+            :type="allSkipped ? 'warning' : 'info'"
+            variant="tonal"
+            density="compact"
+            class="text-caption"
+          >
+            {{ skippedCount }} selected employee(s) are already "{{
+              selectedEmploymentType
+            }}" and will be skipped.
+          </v-alert>
+        </v-col>
+        <v-col cols="12">
+          <v-textarea
+            v-model="conversionNotes"
+            label="Conversion Notes"
+            variant="outlined"
+            rows="3"
+            density="comfortable"
+            :error-messages="errors.conversionNotes"
+            class="form-field"
+            color="primary"
+            hint="Optional notes about this employment type conversion"
+          />
+        </v-col>
+        <v-col cols="12" sm="6">
+          <v-text-field
+            v-model="effectiveDate"
+            label="Effective Date *"
+            type="date"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.effectiveDate"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+      </v-row>
 
       <!-- Action Buttons -->
       <DialogActions
         :loading="isConverting"
-        :disabled="!selectedEmploymentType || selectedEmployees.length === 0"
+        :disabled="
+          !selectedEmploymentType ||
+          selectedEmployees.length === 0 ||
+          allSkipped
+        "
         submit-text="Convert Employment Type"
         submit-icon="mdi-account-convert"
         :on-cancel="() => dialogStore.closeAndResetDialog()"
@@ -101,6 +106,7 @@ import {
 import SelectedEmployeesSummary from "./SelectedEmployeesSummary.vue";
 import DialogActions from "./DialogActions.vue";
 import { useBulkDialogForm } from "../../../composables/useBulkDialogForm";
+import { useApplicableEmployees } from "../../../composables/useApplicableEmployees";
 
 const dialogStore = useDialogStore();
 const appStore = useAppStore();
@@ -126,6 +132,12 @@ const [effectiveDate] = defineField("effectiveDate");
 // State
 const isConverting = ref(false);
 
+// Skip employees already of the chosen employment type — converting is a no-op.
+const { applicableIds, skippedCount, allSkipped } = useApplicableEmployees(
+  selectedEmployees,
+  (emp) => emp.employmentType !== selectedEmploymentType.value
+);
+
 // Methods
 // Selection helpers handled by SelectedEmployeesSummary component
 
@@ -147,10 +159,12 @@ const convertEmploymentType = async () => {
       return;
     }
 
-    // Use the bulk convert method from the store
-    const employeeIds = selectedEmployees.value
-      .map((emp) => emp._id)
-      .filter((id) => id) as string[];
+    // Only convert employees not already of the chosen type.
+    const employeeIds = applicableIds.value;
+    if (employeeIds.length === 0) {
+      isConverting.value = false;
+      return;
+    }
 
     appStore.bulkConvertEmploymentType(
       employeeIds,

--- a/client/src/components/baseDialog/dialogContent/DialogActions.vue
+++ b/client/src/components/baseDialog/dialogContent/DialogActions.vue
@@ -1,24 +1,19 @@
 <template>
-  <div class="d-flex justify-end mt-4 gap-3">
-    <v-btn
-      color="grey"
-      variant="outlined"
-      :disabled="loading"
-      @click="onCancel"
-    >
-      <v-icon class="mr-2" size="small">mdi-close</v-icon>
-      Cancel
-    </v-btn>
-    <v-btn
-      color="primary"
-      :loading="loading"
-      :disabled="disabled"
-      @click="onSubmit"
-      class="ml-3"
-    >
-      <v-icon class="mr-2" size="small" :icon="submitIcon" />
-      {{ submitText }}
-    </v-btn>
+  <div class="dialog-actions">
+    <v-divider class="mb-4" />
+    <div class="d-flex justify-end align-center gap-3">
+      <v-btn variant="text" :disabled="loading" @click="onCancel"> Cancel </v-btn>
+      <v-btn
+        color="primary"
+        variant="flat"
+        :loading="loading"
+        :disabled="disabled"
+        @click="onSubmit"
+      >
+        <v-icon class="mr-2" size="small" :icon="submitIcon" />
+        {{ submitText }}
+      </v-btn>
+    </div>
   </div>
 </template>
 
@@ -33,4 +28,8 @@ defineProps<{
 }>();
 </script>
 
-<style scoped></style>
+<style scoped>
+.dialog-actions {
+  margin-top: 20px;
+}
+</style>

--- a/client/src/components/baseDialog/dialogContent/RehireEmployee.vue
+++ b/client/src/components/baseDialog/dialogContent/RehireEmployee.vue
@@ -2,182 +2,159 @@
   <div class="rehire-employee-form">
     <SelectedEmployeesSummary />
 
+    <v-alert
+      v-if="skippedCount > 0"
+      :type="allSkipped ? 'warning' : 'info'"
+      variant="tonal"
+      density="compact"
+      class="text-caption mb-3"
+    >
+      {{ skippedCount }} selected employee(s) are not terminated and cannot be
+      rehired — they will be skipped.
+    </v-alert>
+
     <!-- Rehire Information Form -->
     <v-form>
-      <v-card variant="outlined" class="section-card mb-4">
-        <v-card-title class="text-subtitle-1 section-header py-2">
-          <v-icon class="mr-2" size="small">mdi-account-plus</v-icon>
-          Rehire Information
-        </v-card-title>
-        <v-card-text class="pa-3">
-          <v-row dense>
-            <v-col cols="12" md="6">
-              <v-text-field
-                v-model="rehireDate"
-                label="Rehire Date *"
-                type="date"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.rehireDate"
-                class="form-field"
-                color="primary"
-                hint="Date when the employee will be rehired"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12" md="6">
-              <v-select
-                v-model="newDepartment"
-                :items="departmentOptions"
-                label="Department *"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.department"
-                class="form-field"
-                color="primary"
-                hint="Department for the rehired employee"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12" md="6">
-              <v-text-field
-                v-model="newPosition"
-                label="Position *"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.position"
-                class="form-field"
-                color="primary"
-                hint="Job position for the rehired employee"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12" md="6">
-              <v-select
-                v-model="newJobLevel"
-                :items="appStore.formOptions.jobLevels as string[]"
-                label="Job Level *"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.jobLevel"
-                class="form-field"
-                color="primary"
-                hint="Job level for the rehired employee"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12" md="6">
-              <v-text-field
-                v-model="newSalary"
-                label="Salary *"
-                type="number"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.salary"
-                class="form-field"
-                color="primary"
-                hint="Annual salary for the rehired employee"
-                persistent-hint
-                prefix="$"
-              />
-            </v-col>
-            <v-col cols="12" md="6">
-              <v-select
-                v-model="newEmploymentType"
-                :items="appStore.formOptions.employmentTypes as string[]"
-                label="Employment Type *"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.employmentType"
-                class="form-field"
-                color="primary"
-                hint="Employment type for the rehired employee"
-                persistent-hint
-              />
-            </v-col>
-          </v-row>
-        </v-card-text>
-      </v-card>
+      <div class="dialog-subhead">Rehire Information</div>
+      <v-row dense>
+        <v-col cols="12" md="6">
+          <v-text-field
+            v-model="rehireDate"
+            label="Rehire Date *"
+            type="date"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.rehireDate"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-select
+            v-model="newDepartment"
+            :items="departmentOptions"
+            label="Department *"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.department"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-text-field
+            v-model="newPosition"
+            label="Position *"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.position"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-select
+            v-model="newJobLevel"
+            :items="jobLevelOptions"
+            item-title="title"
+            item-value="value"
+            label="Job Level *"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.jobLevel"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-text-field
+            v-model="newSalary"
+            label="Salary *"
+            type="number"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.salary"
+            class="form-field"
+            color="primary"
+            prefix="$"
+          />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-select
+            v-model="newEmploymentType"
+            :items="appStore.formOptions.employmentTypes as string[]"
+            label="Employment Type *"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.employmentType"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+      </v-row>
 
-      <!-- Manager Assignment -->
-      <v-card variant="outlined" class="section-card mb-4">
-        <v-card-title class="text-subtitle-1 section-header py-2">
-          <v-icon class="mr-2" size="small">mdi-account-tie</v-icon>
-          Manager Assignment
-        </v-card-title>
-        <v-card-text class="pa-3">
-          <v-row dense>
-            <v-col cols="12">
-              <v-select
-                v-model="selectedManagerId"
-                :items="managerOptions"
-                label="Select Manager"
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.managerId"
-                class="form-field"
-                color="primary"
-                item-title="title"
-                item-value="value"
-                clearable
-                :hint="
-                  selectedManagerId
-                    ? `Manager: ${getSelectedManagerInfo()}`
-                    : 'Choose a manager for the rehired employee (optional)'
-                "
-                persistent-hint
-              >
-                <template v-slot:item="{ props }">
-                  <v-list-item v-bind="props">
-                    <template v-slot:prepend>
-                      <v-avatar size="32" color="primary">
-                        <v-icon icon="mdi-account-tie" />
-                      </v-avatar>
-                    </template>
-                  </v-list-item>
+      <div class="dialog-subhead">Manager Assignment</div>
+      <v-row dense>
+        <v-col cols="12">
+          <v-select
+            v-model="selectedManagerId"
+            :items="managerOptions"
+            label="Select Manager"
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.managerId"
+            class="form-field"
+            color="primary"
+            item-title="title"
+            item-value="value"
+            clearable
+            no-data-text="No eligible managers for the chosen job level"
+            :hint="
+              selectedManagerId
+                ? `Manager: ${getSelectedManagerInfo()}`
+                : 'Choose a manager for the rehired employee (optional)'
+            "
+            persistent-hint
+          >
+            <template v-slot:item="{ props }">
+              <v-list-item v-bind="props">
+                <template v-slot:prepend>
+                  <v-avatar size="32" color="primary">
+                    <v-icon icon="mdi-account-tie" />
+                  </v-avatar>
                 </template>
-              </v-select>
-            </v-col>
-          </v-row>
-        </v-card-text>
-      </v-card>
+              </v-list-item>
+            </template>
+          </v-select>
+        </v-col>
+      </v-row>
 
-      <!-- Additional Information -->
-      <v-card variant="outlined" class="section-card">
-        <v-card-title class="text-subtitle-1 section-header py-2">
-          <v-icon class="mr-2" size="small">mdi-note-text</v-icon>
-          Additional Information
-        </v-card-title>
-        <v-card-text class="pa-3">
-          <v-row dense>
-            <v-col cols="12">
-              <v-textarea
-                v-model="rehireNotes"
-                label="Rehire Notes"
-                variant="outlined"
-                rows="3"
-                density="compact"
-                :error-messages="errors.rehireNotes"
-                class="form-field"
-                color="primary"
-                hint="Optional notes about the rehiring process"
-                persistent-hint
-              />
-            </v-col>
-          </v-row>
-        </v-card-text>
-      </v-card>
+      <div class="dialog-subhead">Additional Information</div>
+      <v-row dense>
+        <v-col cols="12">
+          <v-textarea
+            v-model="rehireNotes"
+            label="Rehire Notes"
+            variant="outlined"
+            rows="3"
+            density="comfortable"
+            :error-messages="errors.rehireNotes"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+      </v-row>
 
       <!-- Action Buttons -->
       <DialogActions
         :loading="isRehiring"
-        :disabled="!isFormValid || selectedEmployees.length === 0"
+        :disabled="!isFormValid || selectedEmployees.length === 0 || allSkipped"
         submit-text="Rehire Employees"
         submit-icon="mdi-account-plus"
         :on-cancel="() => dialogStore.closeAndResetDialog()"
@@ -188,12 +165,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from "vue";
+import { ref, computed, onMounted, watch } from "vue";
 import { useForm } from "vee-validate";
 import { toTypedSchema } from "@vee-validate/zod";
 import { useDialogStore } from "../../../stores/dialog";
 import { useAppStore } from "../../../stores/app";
 import type { Manager, JobLevel, EmploymentType } from "../../../types";
+import { getEligibleManagers } from "../../../constants/hierarchy";
 import {
   rehireEmployeeSchema,
   type RehireEmployeeFormData,
@@ -201,6 +179,7 @@ import {
 import SelectedEmployeesSummary from "./SelectedEmployeesSummary.vue";
 import DialogActions from "./DialogActions.vue";
 import { useBulkDialogForm } from "../../../composables/useBulkDialogForm";
+import { useApplicableEmployees } from "../../../composables/useApplicableEmployees";
 
 const dialogStore = useDialogStore();
 const appStore = useAppStore();
@@ -240,13 +219,41 @@ const departmentOptions = computed(() =>
   appStore.departments.map((dept) => dept.name)
 );
 
+// Managers eligible for the level the employee is being rehired at. Until a job
+// level is chosen there's no floor, so all managers are eligible.
 const managerOptions = computed(() =>
-  appStore.managers.map((manager: Manager) => ({
+  getEligibleManagers({
+    reports: selectedEmployees.value,
+    managers: appStore.managers,
+    employees: appStore.employees,
+    reportLevelOverride: (newJobLevel.value as JobLevel) || undefined,
+  }).map((manager: Manager) => ({
     title: manager.name,
     value: manager.id,
     subtitle: `${manager.department} - ${manager.email}`,
     manager: manager,
   }))
+);
+
+// Mirror EmployeeForm's single-CEO rule: only one non-terminated CEO allowed.
+const hasExistingCEO = computed(() =>
+  appStore.employees.some(
+    (emp) => emp.jobLevel === "CEO" && emp.status !== "Terminated"
+  )
+);
+
+const jobLevelOptions = computed(() =>
+  appStore.formOptions.jobLevels.map((lvl) => ({
+    title: lvl,
+    value: lvl,
+    props: { disabled: lvl === "CEO" && hasExistingCEO.value },
+  }))
+);
+
+// Only terminated employees can be rehired — skip anyone still employed.
+const { applicableIds, skippedCount, allSkipped } = useApplicableEmployees(
+  selectedEmployees,
+  (emp) => emp.status === "Terminated"
 );
 
 const isFormValid = computed(() => {
@@ -259,6 +266,16 @@ const isFormValid = computed(() => {
     newSalary.value > 0 &&
     newEmploymentType.value
   );
+});
+
+// If the chosen job level makes the selected manager ineligible, clear it.
+watch([newJobLevel, managerOptions], () => {
+  if (
+    selectedManagerId.value &&
+    !managerOptions.value.some((opt) => opt.value === selectedManagerId.value)
+  ) {
+    selectedManagerId.value = "";
+  }
 });
 
 // Methods
@@ -294,10 +311,12 @@ const rehireEmployees = async () => {
       ? appStore.managers.find((m: Manager) => m.id === selectedManagerId.value)
       : null;
 
-    // Use the bulk rehire method from the store
-    const employeeIds = selectedEmployees.value
-      .map((emp) => emp._id)
-      .filter((id) => id) as string[];
+    // Only rehire employees who are actually terminated.
+    const employeeIds = applicableIds.value;
+    if (employeeIds.length === 0) {
+      isRehiring.value = false;
+      return;
+    }
 
     appStore.bulkRehireEmployees(employeeIds, {
       rehireDate: rehireDate.value || new Date().toISOString().split("T")[0],

--- a/client/src/components/baseDialog/dialogContent/SchedulePerformanceReview.vue
+++ b/client/src/components/baseDialog/dialogContent/SchedulePerformanceReview.vue
@@ -4,172 +4,140 @@
 
     <!-- Performance Review Scheduling Form -->
     <v-form>
-      <v-card variant="outlined" class="section-card">
-        <v-card-title class="text-subtitle-1 section-header py-2">
-          <v-icon class="mr-2" size="small">mdi-calendar-clock</v-icon>
-          Performance Review Details
-        </v-card-title>
-        <v-card-text class="pa-3">
-          <v-row dense>
-            <v-col cols="12" md="6">
-              <v-text-field
-                v-model="reviewDate"
-                label="Review Date *"
-                type="date"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.reviewDate"
-                class="form-field"
-                color="primary"
-                hint="Date when the performance review will be conducted"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12" md="6">
-              <v-text-field
-                v-model="nextReviewDate"
-                label="Next Review Date"
-                type="date"
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.nextReviewDate"
-                class="form-field"
-                color="primary"
-                hint="Date for the following review cycle"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12" md="6">
-              <v-text-field
-                v-model="reviewPeriodStart"
-                label="Review Period Start *"
-                type="date"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.reviewPeriodStart"
-                class="form-field"
-                color="primary"
-                hint="Start date of the performance period being reviewed"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12" md="6">
-              <v-text-field
-                v-model="reviewPeriodEnd"
-                label="Review Period End *"
-                type="date"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.reviewPeriodEnd"
-                class="form-field"
-                color="primary"
-                hint="End date of the performance period being reviewed"
-                persistent-hint
-              />
-            </v-col>
-          </v-row>
-        </v-card-text>
-      </v-card>
+      <div class="dialog-subhead">Review Details</div>
+      <v-row dense>
+        <v-col cols="12" md="6">
+          <v-text-field
+            v-model="reviewDate"
+            label="Review Date *"
+            type="date"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.reviewDate"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-text-field
+            v-model="nextReviewDate"
+            label="Next Review Date"
+            type="date"
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.nextReviewDate"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-text-field
+            v-model="reviewPeriodStart"
+            label="Review Period Start *"
+            type="date"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.reviewPeriodStart"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-text-field
+            v-model="reviewPeriodEnd"
+            label="Review Period End *"
+            type="date"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.reviewPeriodEnd"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+      </v-row>
 
-      <v-card variant="outlined" class="section-card">
-        <v-card-title class="text-subtitle-1 section-header py-2">
-          <v-icon class="mr-2" size="small">mdi-account-tie</v-icon>
-          Reviewer Assignment
-        </v-card-title>
-        <v-card-text class="pa-3">
-          <v-row dense>
-            <v-col cols="12">
-              <v-select
-                v-model="selectedReviewerId"
-                :items="reviewerOptions"
-                label="Select Reviewer *"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.reviewerId"
-                class="form-field"
-                color="primary"
-                item-title="title"
-                item-value="value"
-                clearable
-                :hint="
-                  selectedReviewerId
-                    ? `Reviewer: ${getSelectedReviewerInfo()}`
-                    : 'Choose a reviewer to conduct the performance reviews'
-                "
-                persistent-hint
-              >
-                <template v-slot:item="{ props }">
-                  <v-list-item v-bind="props">
-                    <template v-slot:prepend>
-                      <v-avatar size="32" color="primary">
-                        <v-icon icon="mdi-account-tie" />
-                      </v-avatar>
-                    </template>
-                  </v-list-item>
+      <div class="dialog-subhead">Reviewer Assignment</div>
+      <v-row dense>
+        <v-col cols="12">
+          <v-select
+            v-model="selectedReviewerId"
+            :items="reviewerOptions"
+            label="Select Reviewer *"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.reviewerId"
+            class="form-field"
+            color="primary"
+            item-title="title"
+            item-value="value"
+            clearable
+            no-data-text="No eligible reviewers for the selected employees' level"
+            :hint="
+              selectedReviewerId
+                ? `Reviewer: ${getSelectedReviewerInfo()}`
+                : reviewerOptions.length === 0
+                ? 'No eligible reviewers — a reviewer must be at or above the most senior selected employee'
+                : 'Choose a reviewer to conduct the performance reviews'
+            "
+            persistent-hint
+          >
+            <template v-slot:item="{ props }">
+              <v-list-item v-bind="props">
+                <template v-slot:prepend>
+                  <v-avatar size="32" color="primary">
+                    <v-icon icon="mdi-account-tie" />
+                  </v-avatar>
                 </template>
-              </v-select>
-            </v-col>
-            <v-col cols="12">
-              <v-select
-                v-model="reviewType"
-                :items="reviewTypeOptions"
-                label="Review Type *"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.reviewType"
-                class="form-field"
-                color="primary"
-                hint="Type of performance review to be conducted"
-                persistent-hint
-              />
-            </v-col>
-          </v-row>
-        </v-card-text>
-      </v-card>
+              </v-list-item>
+            </template>
+          </v-select>
+        </v-col>
+        <v-col cols="12">
+          <v-select
+            v-model="reviewType"
+            :items="reviewTypeOptions"
+            label="Review Type *"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.reviewType"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+      </v-row>
 
-      <v-card variant="outlined" class="section-card">
-        <v-card-title class="text-subtitle-1 section-header py-2">
-          <v-icon class="mr-2" size="small">mdi-note-text</v-icon>
-          Additional Information
-        </v-card-title>
-        <v-card-text class="pa-3">
-          <v-row dense>
-            <v-col cols="12">
-              <v-textarea
-                v-model="reviewNotes"
-                label="Review Notes"
-                variant="outlined"
-                rows="3"
-                density="compact"
-                :error-messages="errors.reviewNotes"
-                class="form-field"
-                color="primary"
-                hint="Optional notes or special instructions for the performance review"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12">
-              <v-select
-                v-model="priority"
-                :items="priorityOptions"
-                label="Priority"
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.priority"
-                class="form-field"
-                color="primary"
-                hint="Priority level for scheduling this review"
-                persistent-hint
-              />
-            </v-col>
-          </v-row>
-        </v-card-text>
-      </v-card>
+      <div class="dialog-subhead">Additional Information</div>
+      <v-row dense>
+        <v-col cols="12">
+          <v-textarea
+            v-model="reviewNotes"
+            label="Review Notes"
+            variant="outlined"
+            rows="3"
+            density="comfortable"
+            :error-messages="errors.reviewNotes"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-select
+            v-model="priority"
+            :items="priorityOptions"
+            label="Priority"
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.priority"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+      </v-row>
 
       <!-- Action Buttons -->
       <DialogActions
@@ -191,6 +159,7 @@ import { toTypedSchema } from "@vee-validate/zod";
 import { useDialogStore } from "../../../stores/dialog";
 import { useAppStore } from "../../../stores/app";
 import type { Manager } from "../../../types";
+import { getEligibleManagers } from "../../../constants/hierarchy";
 import {
   scheduleReviewSchema,
   type ScheduleReviewFormData,
@@ -249,8 +218,14 @@ const priorityOptions = [
   { title: "Urgent", value: "urgent" },
 ];
 
+// A reviewer must be able to manage the selected employees: at or above their
+// level, Active/On Leave, Full-time/Part-time, and not one of them.
 const reviewerOptions = computed(() =>
-  appStore.managers.map((manager: Manager) => ({
+  getEligibleManagers({
+    reports: selectedEmployees.value,
+    managers: appStore.managers,
+    employees: appStore.employees,
+  }).map((manager: Manager) => ({
     title: manager.name,
     value: manager.id,
     subtitle: `${manager.department} - ${manager.email}`,

--- a/client/src/components/baseDialog/dialogContent/SelectedEmployeesSummary.vue
+++ b/client/src/components/baseDialog/dialogContent/SelectedEmployeesSummary.vue
@@ -1,53 +1,43 @@
 <template>
-  <v-card variant="outlined" class="mb-4 summary-card dialog-summary">
-    <v-card-title class="text-subtitle-1 section-header py-2">
-      <v-icon class="mr-2" size="small">mdi-account-multiple</v-icon>
-      Selected Employees ({{ selectedEmployees.length }})
-    </v-card-title>
-    <v-card-text class="pa-3">
-      <div v-if="selectedEmployees.length === 0" class="empty-state">
-        <v-icon size="48" color="grey-lighten-1" class="mb-3">
-          mdi-account-off
-        </v-icon>
-        <p class="text-body-2 text-grey-darken-1 mb-0">
-          No employees selected.
-        </p>
-        <p class="text-caption text-grey">
-          Please select employees from the table first.
-        </p>
-      </div>
+  <div class="selected-summary mb-4">
+    <div class="d-flex align-center justify-space-between mb-2">
+      <span class="summary-label">
+        Selected
+        <span class="summary-count">{{ selectedEmployees.length }}</span>
+      </span>
+      <v-btn
+        v-if="selectedEmployees.length > 1"
+        size="x-small"
+        variant="text"
+        color="medium-emphasis"
+        class="text-caption"
+        @click="clearAllEmployees"
+      >
+        Clear all
+      </v-btn>
+    </div>
 
-      <div v-else class="employee-list">
-        <v-chip
-          v-for="employee in selectedEmployees"
-          :key="employee._id"
-          class="ma-1"
-          color="primary"
-          variant="outlined"
-          size="small"
-          closable
-          @click:close="removeEmployee(employee._id)"
-        >
-          <v-icon start icon="mdi-account" />
-          {{ employee.fullName }}
-          <span class="ml-2 text-caption">({{ employee.department }})</span>
-        </v-chip>
+    <div v-if="selectedEmployees.length === 0" class="empty-hint">
+      <v-icon size="18" class="mr-1">mdi-account-off-outline</v-icon>
+      No employees selected — pick some from the table first.
+    </div>
 
-        <div class="mt-3" v-if="selectedEmployees.length > 1">
-          <v-btn
-            size="small"
-            variant="text"
-            color="error"
-            @click="clearAllEmployees"
-            class="text-caption"
-          >
-            <v-icon start size="small">mdi-close-circle</v-icon>
-            Clear All
-          </v-btn>
-        </div>
-      </div>
-    </v-card-text>
-  </v-card>
+    <div v-else class="chip-row">
+      <v-chip
+        v-for="employee in selectedEmployees"
+        :key="employee._id"
+        class="ma-1 ml-0"
+        color="primary"
+        variant="tonal"
+        size="small"
+        closable
+        @click:close="removeEmployee(employee._id)"
+      >
+        {{ employee.fullName }}
+        <span class="ml-1 text-medium-emphasis">· {{ employee.department }}</span>
+      </v-chip>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -67,4 +57,37 @@ const removeEmployee = (employeeId: string | undefined) => {
 const clearAllEmployees = () => appStore.setSelectedEmployees([]);
 </script>
 
-<style scoped></style>
+<style scoped>
+.summary-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-gray);
+}
+.summary-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  margin-left: 4px;
+  border-radius: 10px;
+  background: var(--color-primary-pale);
+  color: var(--color-primary);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+}
+.empty-hint {
+  display: flex;
+  align-items: center;
+  font-size: 0.8125rem;
+  color: var(--color-gray);
+  padding: 4px 0;
+}
+</style>

--- a/client/src/components/baseDialog/dialogContent/StatusChange.vue
+++ b/client/src/components/baseDialog/dialogContent/StatusChange.vue
@@ -4,112 +4,100 @@
 
     <!-- Status Change Form -->
     <v-form>
-      <v-card variant="outlined" class="section-card">
-        <v-card-title class="text-subtitle-1 section-header py-2">
-          <v-icon class="mr-2" size="small">mdi-account-switch</v-icon>
-          Employee Status Change
-        </v-card-title>
-        <v-card-text class="pa-3">
-          <v-row dense>
-            <v-col cols="12">
-              <v-select
-                v-model="newStatus"
-                :items="appStore.formOptions.statuses as string[]"
-                label="New Status *"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.newStatus"
-                class="form-field"
-                color="primary"
-                clearable
-                :hint="
-                  newStatus
-                    ? `Changing status to: ${newStatus}`
-                    : 'Choose the new status for selected employees'
-                "
-                persistent-hint
-              >
-                <template v-slot:item="{ props, item }">
-                  <v-list-item v-bind="props">
-                    <template v-slot:prepend>
-                      <v-avatar size="32" :color="getStatusColor(item.title)">
-                        <v-icon :icon="getStatusIcon(item.title)" />
-                      </v-avatar>
-                    </template>
-                  </v-list-item>
+      <v-row dense>
+        <v-col cols="12">
+          <v-select
+            v-model="newStatus"
+            :items="appStore.formOptions.statuses as string[]"
+            label="New Status *"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.newStatus"
+            class="form-field"
+            color="primary"
+            clearable
+            :hint="
+              newStatus
+                ? `Changing status to: ${newStatus}`
+                : 'Choose the new status for selected employees'
+            "
+            persistent-hint
+          >
+            <template v-slot:item="{ props, item }">
+              <v-list-item v-bind="props">
+                <template v-slot:prepend>
+                  <v-avatar size="32" :color="getStatusColor(item.title)">
+                    <v-icon :icon="getStatusIcon(item.title)" />
+                  </v-avatar>
                 </template>
-              </v-select>
-            </v-col>
-            <v-col cols="12">
-              <v-textarea
-                v-model="statusChangeReason"
-                label="Reason for Status Change"
-                variant="outlined"
-                rows="3"
-                density="compact"
-                :error-messages="errors.statusChangeReason"
-                class="form-field"
-                color="primary"
-                hint="Optional reason or notes about this status change"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12">
-              <v-text-field
-                v-model="effectiveDate"
-                label="Effective Date *"
-                type="date"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.effectiveDate"
-                class="form-field"
-                color="primary"
-                hint="Date when the status change becomes effective"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12">
-              <v-card variant="outlined" class="notification-section">
-                <v-card-title class="text-subtitle-2 py-2">
-                  <v-icon class="mr-2" size="small">mdi-bell-outline</v-icon>
-                  Notifications
-                </v-card-title>
-                <v-card-text class="pa-3">
-                  <v-row dense>
-                    <v-col cols="12" md="6">
-                      <v-checkbox
-                        v-model="notifyEmployee"
-                        label="Notify Employee"
-                        color="primary"
-                        density="compact"
-                        :error-messages="errors.notifyEmployee"
-                        hide-details="auto"
-                      />
-                    </v-col>
-                    <v-col cols="12" md="6">
-                      <v-checkbox
-                        v-model="notifyManager"
-                        label="Notify Manager"
-                        color="primary"
-                        density="compact"
-                        :error-messages="errors.notifyManager"
-                        hide-details="auto"
-                      />
-                    </v-col>
-                  </v-row>
-                </v-card-text>
-              </v-card>
-            </v-col>
-          </v-row>
-        </v-card-text>
-      </v-card>
+              </v-list-item>
+            </template>
+          </v-select>
+        </v-col>
+        <v-col cols="12" v-if="newStatus && skippedCount > 0">
+          <v-alert
+            :type="allSkipped ? 'warning' : 'info'"
+            variant="tonal"
+            density="compact"
+            class="text-caption"
+          >
+            {{ skippedCount }} selected employee(s) are already "{{
+              newStatus
+            }}" and will be skipped.
+          </v-alert>
+        </v-col>
+        <v-col cols="12">
+          <v-textarea
+            v-model="statusChangeReason"
+            label="Reason for Status Change"
+            variant="outlined"
+            rows="3"
+            density="comfortable"
+            :error-messages="errors.statusChangeReason"
+            class="form-field"
+            color="primary"
+            hint="Optional reason or notes about this status change"
+          />
+        </v-col>
+        <v-col cols="12" sm="6">
+          <v-text-field
+            v-model="effectiveDate"
+            label="Effective Date *"
+            type="date"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.effectiveDate"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+        <v-col cols="12">
+          <div class="notify-row">
+            <span class="notify-label">Notify</span>
+            <v-checkbox
+              v-model="notifyEmployee"
+              label="Employee"
+              color="primary"
+              density="compact"
+              hide-details
+            />
+            <v-checkbox
+              v-model="notifyManager"
+              label="Manager"
+              color="primary"
+              density="compact"
+              hide-details
+            />
+          </div>
+        </v-col>
+      </v-row>
 
       <!-- Action Buttons -->
       <DialogActions
         :loading="isChangingStatus"
-        :disabled="!newStatus || selectedEmployees.length === 0"
+        :disabled="!newStatus || selectedEmployees.length === 0 || allSkipped"
         submit-text="Change Status"
         submit-icon="mdi-account-switch"
         :on-cancel="() => dialogStore.closeAndResetDialog()"
@@ -130,6 +118,7 @@ import { statusChangeSchema } from "../../../schemas/statusChange";
 import SelectedEmployeesSummary from "./SelectedEmployeesSummary.vue";
 import DialogActions from "./DialogActions.vue";
 import { useBulkDialogForm } from "../../../composables/useBulkDialogForm";
+import { useApplicableEmployees } from "../../../composables/useApplicableEmployees";
 
 const dialogStore = useDialogStore();
 const appStore = useAppStore();
@@ -156,6 +145,12 @@ const [notifyManager] = defineField("notifyManager");
 
 // State
 const isChangingStatus = ref(false);
+
+// Skip employees already in the chosen status — changing them is a no-op.
+const { applicableIds, skippedCount, allSkipped } = useApplicableEmployees(
+  selectedEmployees,
+  (emp) => emp.status !== newStatus.value
+);
 
 // Methods
 const getStatusColor = (status: string) => {
@@ -206,10 +201,12 @@ const changeEmployeeStatus = async () => {
       return;
     }
 
-    // Use the bulk status change method from the store
-    const employeeIds = selectedEmployees.value
-      .map((emp) => emp._id)
-      .filter((id) => id) as string[];
+    // Only change employees not already in the chosen status.
+    const employeeIds = applicableIds.value;
+    if (employeeIds.length === 0) {
+      isChangingStatus.value = false;
+      return;
+    }
 
     appStore.bulkChangeStatus(
       employeeIds,
@@ -240,7 +237,16 @@ onMounted(() => {
 
 <style scoped>
 /* Component-specific styles only - common styles are in global CSS */
-.notification-section {
-  margin-top: 8px;
+.notify-row {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+.notify-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-gray);
 }
 </style>

--- a/client/src/components/baseDialog/dialogContent/TrainingStatusUpdate.vue
+++ b/client/src/components/baseDialog/dialogContent/TrainingStatusUpdate.vue
@@ -4,121 +4,119 @@
 
     <!-- Training Status Update Form -->
     <v-form>
-      <v-card variant="outlined" class="section-card">
-        <v-card-title class="text-subtitle-1 section-header py-2">
-          <v-icon class="mr-2" size="small">mdi-school</v-icon>
-          Training Status Update
-        </v-card-title>
-        <v-card-text class="pa-3">
-          <v-row dense>
-            <v-col cols="12">
-              <v-select
-                v-model="selectedTrainingStatus"
-                :items="appStore.formOptions.trainingStatuses as string[]"
-                label="New Training Status *"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.trainingStatus"
-                class="form-field"
-                color="primary"
-                clearable
-                :hint="
-                  selectedTrainingStatus
-                    ? `Updating to: ${selectedTrainingStatus}`
-                    : 'Choose the new training status for selected employees'
-                "
-                persistent-hint
-              >
-                <template v-slot:item="{ props }">
-                  <v-list-item v-bind="props">
-                    <template v-slot:prepend>
-                      <v-avatar size="32" color="primary">
-                        <v-icon icon="mdi-school" />
-                      </v-avatar>
-                    </template>
-                  </v-list-item>
+      <v-row dense>
+        <v-col cols="12">
+          <v-select
+            v-model="selectedTrainingStatus"
+            :items="appStore.formOptions.trainingStatuses as string[]"
+            label="New Training Status *"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.trainingStatus"
+            class="form-field"
+            color="primary"
+            clearable
+            :hint="
+              selectedTrainingStatus
+                ? `Updating to: ${selectedTrainingStatus}`
+                : 'Choose the new training status for selected employees'
+            "
+            persistent-hint
+          >
+            <template v-slot:item="{ props }">
+              <v-list-item v-bind="props">
+                <template v-slot:prepend>
+                  <v-avatar size="32" color="primary">
+                    <v-icon icon="mdi-school" />
+                  </v-avatar>
                 </template>
-              </v-select>
-            </v-col>
-            <v-col cols="12">
-              <v-text-field
-                v-model="trainingProgram"
-                label="Training Program"
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.trainingProgram"
-                class="form-field"
-                color="primary"
-                hint="Name of the training program (optional)"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12" md="6">
-              <v-text-field
-                v-model="startDate"
-                label="Start Date"
-                type="date"
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.startDate"
-                class="form-field"
-                color="primary"
-                hint="Training start date (optional)"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12" md="6">
-              <v-text-field
-                v-model="completionDate"
-                label="Completion Date"
-                type="date"
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.completionDate"
-                class="form-field"
-                color="primary"
-                hint="Training completion date (optional)"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12">
-              <v-textarea
-                v-model="trainingNotes"
-                label="Training Notes"
-                variant="outlined"
-                rows="3"
-                density="compact"
-                :error-messages="errors.trainingNotes"
-                class="form-field"
-                color="primary"
-                hint="Optional notes about the training status update"
-                persistent-hint
-              />
-            </v-col>
-            <v-col cols="12">
-              <v-text-field
-                v-model="effectiveDate"
-                label="Effective Date *"
-                type="date"
-                required
-                variant="outlined"
-                density="compact"
-                :error-messages="errors.effectiveDate"
-                class="form-field"
-                color="primary"
-                hint="Date when the training status change becomes effective"
-                persistent-hint
-              />
-            </v-col>
-          </v-row>
-        </v-card-text>
-      </v-card>
+              </v-list-item>
+            </template>
+          </v-select>
+        </v-col>
+        <v-col cols="12" v-if="selectedTrainingStatus && skippedCount > 0">
+          <v-alert
+            :type="allSkipped ? 'warning' : 'info'"
+            variant="tonal"
+            density="compact"
+            class="text-caption"
+          >
+            {{ skippedCount }} selected employee(s) are already "{{
+              selectedTrainingStatus
+            }}" and will be skipped.
+          </v-alert>
+        </v-col>
+        <v-col cols="12">
+          <v-text-field
+            v-model="trainingProgram"
+            label="Training Program"
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.trainingProgram"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-text-field
+            v-model="startDate"
+            label="Start Date"
+            type="date"
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.startDate"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-text-field
+            v-model="completionDate"
+            label="Completion Date"
+            type="date"
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.completionDate"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+        <v-col cols="12">
+          <v-textarea
+            v-model="trainingNotes"
+            label="Training Notes"
+            variant="outlined"
+            rows="3"
+            density="comfortable"
+            :error-messages="errors.trainingNotes"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-text-field
+            v-model="effectiveDate"
+            label="Effective Date *"
+            type="date"
+            required
+            variant="outlined"
+            density="comfortable"
+            :error-messages="errors.effectiveDate"
+            class="form-field"
+            color="primary"
+          />
+        </v-col>
+      </v-row>
 
       <!-- Action Buttons -->
       <DialogActions
         :loading="isUpdating"
-        :disabled="!selectedTrainingStatus || selectedEmployees.length === 0"
+        :disabled="
+          !selectedTrainingStatus ||
+          selectedEmployees.length === 0 ||
+          allSkipped
+        "
         submit-text="Update Training Status"
         submit-icon="mdi-school"
         :on-cancel="() => dialogStore.closeAndResetDialog()"
@@ -142,6 +140,7 @@ import {
 import SelectedEmployeesSummary from "./SelectedEmployeesSummary.vue";
 import DialogActions from "./DialogActions.vue";
 import { useBulkDialogForm } from "../../../composables/useBulkDialogForm";
+import { useApplicableEmployees } from "../../../composables/useApplicableEmployees";
 
 const dialogStore = useDialogStore();
 const appStore = useAppStore();
@@ -171,6 +170,12 @@ const [effectiveDate] = defineField("effectiveDate");
 // State
 const isUpdating = ref(false);
 
+// Skip employees already at the chosen training status — updating is a no-op.
+const { applicableIds, skippedCount, allSkipped } = useApplicableEmployees(
+  selectedEmployees,
+  (emp) => emp.trainingStatus !== selectedTrainingStatus.value
+);
+
 // Methods
 const updateTrainingStatus = async () => {
   isUpdating.value = true;
@@ -190,10 +195,12 @@ const updateTrainingStatus = async () => {
       return;
     }
 
-    // Use the bulk update training status method from the store
-    const employeeIds = selectedEmployees.value
-      .map((emp) => emp._id)
-      .filter((id) => id) as string[];
+    // Only update employees not already at the chosen training status.
+    const employeeIds = applicableIds.value;
+    if (employeeIds.length === 0) {
+      isUpdating.value = false;
+      return;
+    }
 
     appStore.bulkUpdateTrainingStatus(
       employeeIds,

--- a/client/src/components/charts/JobLevelChart.vue
+++ b/client/src/components/charts/JobLevelChart.vue
@@ -16,6 +16,7 @@ import {
   Legend,
   type ChartConfiguration,
 } from "chart.js";
+import { jobLevelRank } from "../../constants/hierarchy";
 
 ChartJS.register(
   CategoryScale,
@@ -68,22 +69,10 @@ const createChart = () => {
     chartInstance.destroy();
   }
 
-  // Define level order for consistent display
-  const levelOrder = [
-    "Entry",
-    "Mid",
-    "Senior",
-    "Lead",
-    "Manager",
-    "Director",
-    "VP",
-    "C-Level",
-  ];
-  const sortedData = [...props.jobLevelData].sort((a, b) => {
-    const aIndex = levelOrder.indexOf(a.level);
-    const bIndex = levelOrder.indexOf(b.level);
-    return (aIndex === -1 ? 999 : aIndex) - (bIndex === -1 ? 999 : bIndex);
-  });
+  // Order by canonical seniority (Entry -> CEO) from the shared hierarchy.
+  const sortedData = [...props.jobLevelData].sort(
+    (a, b) => jobLevelRank(a.level) - jobLevelRank(b.level)
+  );
 
   const data = {
     labels: sortedData.map((level) => level.level),

--- a/client/src/composables/useApplicableEmployees.ts
+++ b/client/src/composables/useApplicableEmployees.ts
@@ -1,0 +1,40 @@
+import { computed, type ComputedRef, type Ref } from "vue";
+import type { Employee } from "../types";
+
+/**
+ * Partition the selected employees into those a bulk action would actually
+ * change ("applicable") and those it would skip (already in the target state, or
+ * not a valid target for this action).
+ *
+ * `isApplicable` may read other reactive values (e.g. the chosen manager/status);
+ * because it runs inside a computed, those dependencies are tracked, so the
+ * partition recomputes as the form changes.
+ */
+export function useApplicableEmployees(
+  selectedEmployees: Ref<Employee[]> | ComputedRef<Employee[]>,
+  isApplicable: (emp: Employee) => boolean
+) {
+  const applicableEmployees = computed(() =>
+    selectedEmployees.value.filter(isApplicable)
+  );
+
+  const applicableIds = computed(
+    () =>
+      applicableEmployees.value
+        .map((e) => e._id)
+        .filter((id): id is string => Boolean(id))
+  );
+
+  const skippedCount = computed(
+    () => selectedEmployees.value.length - applicableEmployees.value.length
+  );
+
+  // Every selected employee is a no-op for the current choice.
+  const allSkipped = computed(
+    () =>
+      selectedEmployees.value.length > 0 &&
+      applicableEmployees.value.length === 0
+  );
+
+  return { applicableEmployees, applicableIds, skippedCount, allSkipped };
+}

--- a/client/src/constants/hierarchy.ts
+++ b/client/src/constants/hierarchy.ts
@@ -1,0 +1,154 @@
+// Single source of truth for the org hierarchy.
+//
+// Every place in the app that orders, ranks, or validates job levels should
+// derive from the constants/helpers here so the rules can never drift apart.
+// The canonical seniority, lowest -> highest:
+//   Entry < Mid < Senior < Lead < Manager < Director < VP < C-Level < CEO
+//
+// See the "canonical hierarchy" section of the hierarchy audit plan for the
+// assignment rules these helpers enforce.
+
+import type { Employee, EmploymentType, JobLevel, Manager } from "../types";
+
+// Canonical order, lowest seniority first. `jobLevelRank` is the index, so a
+// higher number means more senior.
+export const JOB_LEVELS: JobLevel[] = [
+  "Entry",
+  "Mid",
+  "Senior",
+  "Lead",
+  "Manager",
+  "Director",
+  "VP",
+  "C-Level",
+  "CEO",
+];
+
+// Levels that make someone a people-manager by title alone.
+export const MANAGER_LEVELS: JobLevel[] = [
+  "Manager",
+  "Director",
+  "VP",
+  "C-Level",
+  "CEO",
+];
+
+// Employment types allowed to manage people (rule 3).
+export const ELIGIBLE_MANAGER_TYPES: EmploymentType[] = ["Full-time", "Part-time"];
+
+// Employee statuses allowed to manage people (rule 2).
+const ELIGIBLE_MANAGER_STATUSES = ["Active", "On Leave"] as const;
+
+/** Seniority rank for a level. Higher = more senior. Unknown levels rank -1. */
+export function jobLevelRank(level: JobLevel | string | undefined | null): number {
+  if (!level) return -1;
+  return JOB_LEVELS.indexOf(level as JobLevel);
+}
+
+/** Whether a level is a people-manager level by title. */
+export function isManagerLevel(level: JobLevel | string | undefined | null): boolean {
+  return !!level && MANAGER_LEVELS.includes(level as JobLevel);
+}
+
+/** Whether an employment type is allowed to manage people (rule 3). */
+export function isEligibleManagerType(
+  employmentType: EmploymentType | string | undefined | null
+): boolean {
+  return (
+    !!employmentType &&
+    ELIGIBLE_MANAGER_TYPES.includes(employmentType as EmploymentType)
+  );
+}
+
+/** Rule 1: a manager's level must be equal to or higher than the report's. */
+export function canManage(
+  managerLevel: JobLevel | string | undefined | null,
+  reportLevel: JobLevel | string | undefined | null
+): boolean {
+  const reportRank = jobLevelRank(reportLevel);
+  if (reportRank < 0) return true; // unknown report level: don't block
+  return jobLevelRank(managerLevel) >= reportRank;
+}
+
+/** Sort comparator for employees by seniority, most senior first (CEO -> Entry). */
+export function bySeniorityDesc(
+  a: { jobLevel?: JobLevel },
+  b: { jobLevel?: JobLevel }
+): number {
+  return jobLevelRank(b.jobLevel) - jobLevelRank(a.jobLevel);
+}
+
+interface EligibleManagerOptions {
+  /** The employee(s) being assigned a manager. */
+  reports: Employee | Employee[];
+  /** Candidate manager pool (e.g. appStore.managers). */
+  managers: Manager[];
+  /** Full employee list, used to look up status/employmentType and detect cycles. */
+  employees: Employee[];
+  /**
+   * Optional level override for the report(s) (e.g. a job level chosen in a
+   * rehire form that differs from the stored record). Used as the seniority floor.
+   */
+  reportLevelOverride?: JobLevel;
+}
+
+/**
+ * Return the managers that may be assigned to the given report(s), enforcing the
+ * canonical assignment rules:
+ *   1. manager level >= the most-senior report's level
+ *   2. manager is Active / On Leave
+ *   3. manager is Full-time / Part-time
+ *   4. no self-management and no cycles (manager must not be, or transitively
+ *      report to, any of the reports)
+ *
+ * Status and employment type live on the full Employee record (the Manager type
+ * doesn't carry them), so they're looked up by id from `employees`.
+ */
+export function getEligibleManagers({
+  reports,
+  managers,
+  employees,
+  reportLevelOverride,
+}: EligibleManagerOptions): Manager[] {
+  const reportList = Array.isArray(reports) ? reports : [reports];
+  const byId = new Map(employees.map((e) => [e._id ?? "", e]));
+
+  // Seniority floor: an explicit override (e.g. a rehire's chosen level) wins
+  // outright; otherwise it's the most-senior report's level.
+  const floorRank =
+    reportLevelOverride !== undefined
+      ? jobLevelRank(reportLevelOverride)
+      : Math.max(-1, ...reportList.map((r) => jobLevelRank(r.jobLevel)));
+
+  const reportIds = new Set(reportList.map((r) => r._id).filter(Boolean) as string[]);
+
+  // True if `managerId` is, or transitively reports up to, any of the reports.
+  const reportsUpToAReport = (managerId: string): boolean => {
+    let current: string | undefined = managerId;
+    const seen = new Set<string>();
+    while (current && !seen.has(current)) {
+      if (reportIds.has(current)) return true;
+      seen.add(current);
+      current = byId.get(current)?.managerId || undefined;
+    }
+    return false;
+  };
+
+  return managers.filter((m) => {
+    // Rule 4: not one of the reports themselves, and not (transitively) below them.
+    if (reportIds.has(m.id)) return false;
+    if (reportsUpToAReport(m.id)) return false;
+
+    // Rule 1: seniority floor.
+    if (floorRank >= 0 && jobLevelRank(m.jobLevel) < floorRank) return false;
+
+    // Rules 2 & 3: status + employment type (from the full record when available).
+    const record = byId.get(m.id);
+    if (record) {
+      if (!ELIGIBLE_MANAGER_STATUSES.includes(record.status as never)) return false;
+      if (!isEligibleManagerType(record.employmentType)) return false;
+    }
+
+    return true;
+  });
+}

--- a/client/src/constants/orgChart.ts
+++ b/client/src/constants/orgChart.ts
@@ -1,0 +1,14 @@
+import type { InjectionKey } from "vue";
+
+// Shared API the OrgChart view provides to the recursive OrgChartNode children,
+// so collapse/expand and focus work without prop/emit plumbing through the tree.
+export interface OrgChartApi {
+  /** Whether a node's children are currently hidden. */
+  isCollapsed: (id: string) => boolean;
+  /** Toggle a node's collapsed state. */
+  toggleCollapsed: (id: string) => void;
+  /** Re-root the chart on a node (show only its subtree). */
+  focusNode: (id: string) => void;
+}
+
+export const ORG_CHART_API: InjectionKey<OrgChartApi> = Symbol("orgChartApi");

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -8,6 +8,7 @@ import Analytics from "../views/Analytics.vue";
 import OrgChart from "../views/OrgChart.vue";
 import SearchEmployees from "../views/SearchEmployees.vue";
 import { useAuthStore } from "../stores/auth";
+import { useAppStore } from "../stores/app";
 
 const routes = [
   {
@@ -121,6 +122,16 @@ const routes = [
     component: AccordionWrapper,
   },
   {
+    path: "/by-job-level",
+    name: "By Job Level",
+    meta: {
+      title: "By Job Level",
+      description: "Employees grouped by seniority / job level",
+      requiresAuth: true,
+    },
+    component: AccordionWrapper,
+  },
+  {
     path: "/performance-reviews",
     name: "Performance Reviews",
     meta: {
@@ -208,6 +219,14 @@ router.beforeEach((to, _from, next) => {
   // Allow navigation
   else {
     next();
+  }
+});
+
+// Bulk selection is per-view: clear it whenever the route actually changes so a
+// selection made on one "By X" view doesn't carry over to another.
+router.afterEach((to, from) => {
+  if (to.path !== from.path) {
+    useAppStore().setSelectedEmployees([]);
   }
 });
 

--- a/client/src/schemas/employee.ts
+++ b/client/src/schemas/employee.ts
@@ -1,17 +1,13 @@
 import { z } from "zod";
+import type { JobLevel } from "../types";
+import { JOB_LEVELS } from "../constants/hierarchy";
 
-// Define the job levels as a Zod enum
-const jobLevelSchema = z.enum([
-  "Entry",
-  "Mid",
-  "Senior",
-  "Lead",
-  "Manager",
-  "Director",
-  "VP",
-  "C-Level",
-  "CEO",
-] as const);
+// Define the job levels as a Zod enum, derived from the canonical ordering so it
+// can never drift from the rest of the app. The cast keeps z.infer narrowed to
+// the JobLevel union rather than widening to string.
+const jobLevelSchema = z.enum(
+  JOB_LEVELS as unknown as [JobLevel, ...JobLevel[]]
+);
 
 // Define the employment type schema
 const employmentTypeSchema = z.enum([

--- a/client/src/stores/app.ts
+++ b/client/src/stores/app.ts
@@ -17,6 +17,7 @@ import type {
   PerformanceAnalytics,
   BusinessUnit,
 } from "../types";
+import { JOB_LEVELS } from "../constants/hierarchy";
 import { useNotificationStore } from "./notification";
 import { useAuthStore } from "./auth";
 
@@ -2243,17 +2244,8 @@ export const useAppStore = defineStore("app", () => {
 
   // Form Options - Centralized for consistency across the app
   const formOptions = {
-    jobLevels: [
-      "Entry",
-      "Mid",
-      "Senior",
-      "Lead",
-      "Manager",
-      "Director",
-      "VP",
-      "C-Level",
-      "CEO",
-    ] as JobLevel[],
+    // Derived from the canonical hierarchy ordering (constants/hierarchy.ts).
+    jobLevels: JOB_LEVELS,
 
     employmentTypes: [
       "Full-time",
@@ -2413,6 +2405,10 @@ export const useAppStore = defineStore("app", () => {
 
   const getByDepartment = async (): Promise<Employee[]> => {
     return employees.value.filter((employee) => employee.department);
+  };
+
+  const getByJobLevel = async (): Promise<Employee[]> => {
+    return employees.value.filter((employee) => employee.jobLevel);
   };
 
   const getActiveTerminated = async (): Promise<Employee[]> => {
@@ -2920,6 +2916,7 @@ export const useAppStore = defineStore("app", () => {
     getRecentHires,
     getByManager,
     getByDepartment,
+    getByJobLevel,
     getActiveTerminated,
     getContractEmployees,
     getFormerEmployees,

--- a/client/src/styles/forms.css
+++ b/client/src/styles/forms.css
@@ -44,8 +44,15 @@
   background-color: var(--color-surface) !important;
 }
 
-/* Validation messages */
+/* Helper / validation messages.
+   Vuetify reuses .v-messages__message for both hints and errors, so default it
+   to a quiet grey hint and only paint it red when the field is in an error state. */
 .v-messages__message {
+  color: var(--color-gray);
+  font-weight: 400;
+}
+
+.v-input--error .v-messages__message {
   color: var(--color-error);
   font-weight: 500;
 }
@@ -75,6 +82,20 @@
 .section-header :deep(.v-icon),
 .section-header .v-icon {
   color: var(--color-primary);
+}
+
+/* Lightweight section heading for inside dialogs — a quiet label instead of the
+   heavy bordered card + band used on full-page forms. */
+.dialog-subhead {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-gray);
+  margin: 0 0 8px;
+}
+.dialog-subhead:not(:first-child) {
+  margin-top: 20px;
 }
 
 /* Form page header band */

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -221,7 +221,7 @@ export interface GroupByInfo {
 // This should match the keys in the Employee interface pick
 export type GroupByOption = keyof Pick<
   Employee,
-  "managerName" | "department" | "status"
+  "managerName" | "department" | "status" | "jobLevel"
 >;
 
 // Performance Review Enhanced Types

--- a/client/src/views/AccordionWrapper.vue
+++ b/client/src/views/AccordionWrapper.vue
@@ -107,6 +107,30 @@ const loadData = async () => {
         };
         tableActions.value = ["training-status-update", "export-data"];
         break;
+      case "By Job Level":
+        title.value = "By Job Level";
+        subtitle.value = "Employees by seniority / job level";
+        enableSearch.value = true;
+        enableActions.value = true;
+        enableExport.value = true;
+        enableOpenRecord.value = true;
+        enableSelect.value = true;
+        items.value = await appStore.getByJobLevel();
+        tableColumns.value = [
+          "firstName",
+          "lastName",
+          "department",
+          "position",
+          "managerName",
+          "workEmail",
+          "status",
+        ];
+        groupByInfo.value = {
+          groupBy: "jobLevel",
+          groupByOptions: ["jobLevel"],
+        };
+        tableActions.value = ["assign-to-manager", "export-data"];
+        break;
       case "By Status":
         title.value = "By Status";
         subtitle.value = "Employees by status";

--- a/client/src/views/EmployeeForm.vue
+++ b/client/src/views/EmployeeForm.vue
@@ -969,6 +969,7 @@ import { useRouter, useRoute } from "vue-router";
 import { useForm } from "vee-validate";
 import { toTypedSchema } from "@vee-validate/zod";
 import { useAppStore } from "../stores/app";
+import { getEligibleManagers } from "../constants/hierarchy";
 import type {
   Employee,
   JobLevel,
@@ -1146,14 +1147,6 @@ const departmentOptions = computed(() =>
   }))
 );
 
-const managerOptions = computed(() =>
-  appStore.managers.map((manager) => ({
-    title: manager.name,
-    value: manager.id,
-    subtitle: `${manager.department} - ${manager.email}`,
-  }))
-);
-
 // CEO constraints: only one CEO allowed; CEO does not require a manager
 const hasExistingCEO = computed(() => {
   return appStore.employees.some(
@@ -1187,33 +1180,52 @@ const hrAssigneeOptions = computed(() => [
     })),
 ]);
 
-// Filtered managers based on selected department
+// Managers eligible for this employee under the canonical hierarchy rules
+// (rank >= the chosen job level, Active/On Leave, Full-time/Part-time, no
+// self/cycle). Cross-department reporting is allowed — same-department managers
+// are surfaced first rather than excluded. The currently-assigned manager is
+// always kept so editing an existing record never silently drops it.
 const filteredManagerOptions = computed(() => {
-  const base = managerOptions.value.filter((opt) => {
-    // Exclude self if editing and employee is a manager option
-    if (
-      isEditMode.value &&
-      employeeId.value &&
-      opt.value === employeeId.value
-    ) {
-      return false;
-    }
-    // Exclude direct reports to avoid circular relationships
-    if (
-      isEditMode.value &&
-      employee.value?.directReports &&
-      employee.value.directReports.includes(opt.value as string)
-    ) {
-      return false;
-    }
-    return true;
+  const eligible = getEligibleManagers({
+    reports: isEditMode.value && employee.value ? [employee.value] : [],
+    managers: appStore.managers,
+    employees: appStore.employees,
+    reportLevelOverride: (jobLevel.value as JobLevel) || undefined,
   });
 
-  if (!department.value) return base;
-  return base.filter((opt) => {
-    const managerData = appStore.managers.find((m) => m.id === opt.value);
-    return managerData?.department === department.value;
-  });
+  const pool = [...eligible];
+  if (
+    managerId.value &&
+    !pool.some((m) => m.id === managerId.value)
+  ) {
+    const current = appStore.managers.find((m) => m.id === managerId.value);
+    if (current) pool.push(current);
+  }
+
+  const options = pool.map((manager) => ({
+    title: manager.name,
+    value: manager.id,
+    subtitle: `${manager.department} - ${manager.email}`,
+  }));
+
+  if (!department.value) return options;
+  // Stable sort: same-department managers first.
+  return options
+    .map((opt, i) => ({ opt, i }))
+    .sort((a, b) => {
+      const aSame =
+        appStore.managers.find((m) => m.id === a.opt.value)?.department ===
+        department.value
+          ? 0
+          : 1;
+      const bSame =
+        appStore.managers.find((m) => m.id === b.opt.value)?.department ===
+        department.value
+          ? 0
+          : 1;
+      return aSame - bSame || a.i - b.i;
+    })
+    .map(({ opt }) => opt);
 });
 
 // Initialize form with employee data in edit mode

--- a/client/src/views/OrgChart.vue
+++ b/client/src/views/OrgChart.vue
@@ -131,18 +131,71 @@
         <div class="card-head">
           <v-icon size="20">mdi-sitemap-outline</v-icon>
           Organizational Hierarchy
+          <div class="chart-tools">
+            <v-btn size="small" variant="text" @click="expandAll">
+              Expand all
+            </v-btn>
+            <v-btn size="small" variant="text" @click="collapseAll">
+              Collapse all
+            </v-btn>
+            <v-divider vertical class="mx-1" />
+            <v-btn
+              icon="mdi-minus"
+              size="x-small"
+              variant="text"
+              title="Zoom out"
+              @click="zoomOut"
+            />
+            <span class="zoom-label tabular-nums">{{ Math.round(zoom * 100) }}%</span>
+            <v-btn
+              icon="mdi-plus"
+              size="x-small"
+              variant="text"
+              title="Zoom in"
+              @click="zoomIn"
+            />
+            <v-btn size="small" variant="text" @click="fitToWidth">Fit</v-btn>
+            <v-btn
+              icon="mdi-backup-restore"
+              size="x-small"
+              variant="text"
+              title="Reset zoom"
+              @click="resetZoom"
+            />
+          </div>
         </div>
 
-        <div class="org-chart-container">
-          <div v-if="filteredOrgChart.length === 0" class="empty-state ma-4">
+        <!-- Focus breadcrumb -->
+        <div v-if="focusedId" class="focus-bar">
+          <v-icon size="15">mdi-target</v-icon>
+          <button class="crumb" @click="clearFocus">Full org</button>
+          <template v-for="(c, i) in focusBreadcrumb" :key="c._id">
+            <v-icon size="13">mdi-chevron-right</v-icon>
+            <button
+              class="crumb"
+              :class="{ active: i === focusBreadcrumb.length - 1 }"
+              @click="c._id && orgApi.focusNode(c._id)"
+            >
+              {{ c.fullName }}
+            </button>
+          </template>
+        </div>
+
+        <div class="org-chart-container" ref="containerRef">
+          <div v-if="displayRoots.length === 0" class="empty-state ma-4">
             <v-icon icon="mdi-account-search-outline" size="40"></v-icon>
             <p class="mt-2 mb-0">No employees found matching your criteria</p>
           </div>
-          <div v-else class="org-hierarchy">
+          <div
+            v-else
+            class="org-hierarchy org-canvas"
+            ref="canvasRef"
+            :style="{ zoom }"
+          >
             <!-- Root level employees (CEO, top executives) -->
             <div class="root-level">
               <OrgChartNode
-                v-for="employee in filteredOrgChart"
+                v-for="employee in displayRoots"
                 :key="employee._id"
                 :employee="employee"
                 :level="0"
@@ -158,11 +211,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from "vue";
+import { ref, reactive, computed, provide, watch, onMounted } from "vue";
 import { useRouter } from "vue-router";
 import { useAppStore } from "../stores/app";
 import type { Employee, JobLevel } from "../types";
+import { bySeniorityDesc } from "../constants/hierarchy";
 import OrgChartNode from "../components/OrgChartNode.vue";
+import { ORG_CHART_API, type OrgChartApi } from "../constants/orgChart";
 
 const router = useRouter();
 const appStore = useAppStore();
@@ -170,6 +225,19 @@ const appStore = useAppStore();
 // Reactive data
 const loading = ref(true);
 const employees = ref<Employee[]>([]);
+
+// Levels 0..DEFAULT_VISIBLE_DEPTH are shown by default; deeper nodes start
+// collapsed so the chart isn't an endless horizontal scroll.
+const DEFAULT_VISIBLE_DEPTH = 2;
+
+// Collapse state — a node is collapsed (children hidden) if its id is in the set.
+const collapsedIds = reactive(new Set<string>());
+// Focus / re-root — when set, only this node's subtree renders.
+const focusedId = ref<string | null>(null);
+// Zoom (CSS `zoom`, which scales layout so the scroll footprint shrinks too).
+const zoom = ref(1);
+const containerRef = ref<HTMLElement | null>(null);
+const canvasRef = ref<HTMLElement | null>(null);
 
 // Local enriched node type for org chart
 type EmployeeNode = Employee & {
@@ -204,24 +272,10 @@ const totalDepartments = computed(() => {
 
 // Organization chart structure
 const orgChart = computed<EmployeeNode[]>(() => {
-  // Rank map for job levels to help with consistent ordering
-  const jobLevelRank: Record<JobLevel, number> = {
-    CEO: 0,
-    "C-Level": 1,
-    VP: 2,
-    Director: 3,
-    Manager: 4,
-    Lead: 5,
-    Senior: 6,
-    Mid: 7,
-    Entry: 8,
-  };
-
   const compareNodes = (a: EmployeeNode, b: EmployeeNode) => {
-    // Sort by job level rank
-    const aRank = jobLevelRank[a.jobLevel] ?? 999;
-    const bRank = jobLevelRank[b.jobLevel] ?? 999;
-    if (aRank !== bRank) return aRank - bRank;
+    // Most senior first (CEO -> Entry), then by department/position/name.
+    const bySeniority = bySeniorityDesc(a, b);
+    if (bySeniority !== 0) return bySeniority;
     if (a.department !== b.department)
       return a.department.localeCompare(b.department);
     if (a.position !== b.position) return a.position.localeCompare(b.position);
@@ -345,6 +399,94 @@ const totalManagers = computed(() => {
   return count;
 });
 
+// Flat node lookup (built from the tree) for focus / breadcrumb.
+const nodeById = computed(() => {
+  const map = new Map<string, EmployeeNode>();
+  const stack = [...orgChart.value];
+  while (stack.length) {
+    const n = stack.pop()!;
+    if (n._id) map.set(n._id, n);
+    for (const c of n.children) stack.push(c);
+  }
+  return map;
+});
+
+// --- Collapse / expand ---
+const orgApi: OrgChartApi = {
+  // While searching, ignore collapse so matches are never hidden.
+  isCollapsed: (id) => (searchQuery.value ? false : collapsedIds.has(id)),
+  toggleCollapsed: (id) =>
+    collapsedIds.has(id) ? collapsedIds.delete(id) : collapsedIds.add(id),
+  focusNode: (id) => {
+    focusedId.value = id;
+  },
+};
+provide(ORG_CHART_API, orgApi);
+
+const seedCollapse = (nodes: EmployeeNode[]) => {
+  const stack = [...nodes];
+  while (stack.length) {
+    const n = stack.pop()!;
+    if (n._id && n.children.length > 0 && n.computedLevel >= DEFAULT_VISIBLE_DEPTH) {
+      collapsedIds.add(n._id);
+    }
+    for (const c of n.children) stack.push(c);
+  }
+};
+
+// Seed the default-collapsed state once the tree is first available.
+const seeded = ref(false);
+watch(
+  orgChart,
+  (nodes) => {
+    if (seeded.value || nodes.length === 0) return;
+    seedCollapse(nodes);
+    seeded.value = true;
+  },
+  { immediate: true }
+);
+
+const expandAll = () => collapsedIds.clear();
+const collapseAll = () => {
+  collapsedIds.clear();
+  for (const [id, node] of nodeById.value) {
+    if (node.children.length > 0) collapsedIds.add(id);
+  }
+};
+
+// --- Zoom ---
+const clampZoom = (z: number) => Math.min(1, Math.max(0.3, z));
+const zoomIn = () => (zoom.value = clampZoom(zoom.value + 0.1));
+const zoomOut = () => (zoom.value = clampZoom(zoom.value - 0.1));
+const resetZoom = () => (zoom.value = 1);
+const fitToWidth = () => {
+  const container = containerRef.value;
+  const canvas = canvasRef.value;
+  if (!container || !canvas) return;
+  // offsetWidth already reflects the current zoom, so unscale to get natural width.
+  const natural = canvas.offsetWidth / zoom.value;
+  if (!natural) return;
+  zoom.value = clampZoom((container.clientWidth - 48) / natural);
+};
+
+// --- Focus / re-root ---
+const focusBreadcrumb = computed<EmployeeNode[]>(() => {
+  if (!focusedId.value) return [];
+  const byEmpId = new Map(employees.value.map((e) => [e._id ?? "", e]));
+  const path: EmployeeNode[] = [];
+  let current: string | null | undefined = focusedId.value;
+  const seen = new Set<string>();
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    const node = nodeById.value.get(current);
+    if (node) path.unshift(node);
+    current = byEmpId.get(current)?.managerId;
+  }
+  return path;
+});
+
+const clearFocus = () => (focusedId.value = null);
+
 // Filtered organization chart
 const filteredOrgChart = computed<EmployeeNode[]>(() => {
   if (
@@ -397,6 +539,15 @@ const filteredOrgChart = computed<EmployeeNode[]>(() => {
     .filter((emp) => emp !== null) as EmployeeNode[];
 });
 
+// What actually renders: a focused subtree if focus is set, else the filtered tree.
+const displayRoots = computed<EmployeeNode[]>(() => {
+  if (focusedId.value) {
+    const node = nodeById.value.get(focusedId.value);
+    return node ? [node] : filteredOrgChart.value;
+  }
+  return filteredOrgChart.value;
+});
+
 // Methods
 const loadData = async () => {
   try {
@@ -427,4 +578,56 @@ onMounted(() => {
 
 <style scoped>
 /* Component-specific styles only - common styles are in global CSS */
+
+/* Chart toolbar (right side of the card header) */
+.chart-tools {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  font-weight: 500;
+}
+.zoom-label {
+  min-width: 40px;
+  text-align: center;
+  font-size: 0.8125rem;
+  color: var(--color-slate);
+}
+
+/* Focus breadcrumb bar */
+.focus-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 8px 20px;
+  background: var(--color-primary-pale);
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.8125rem;
+}
+.focus-bar .v-icon {
+  color: var(--color-primary);
+}
+.crumb {
+  background: none;
+  border: none;
+  padding: 2px 4px;
+  cursor: pointer;
+  color: var(--color-primary);
+  font: inherit;
+  border-radius: 4px;
+}
+.crumb:hover {
+  background: rgba(var(--color-primary-rgb), 0.12);
+}
+.crumb.active {
+  color: var(--color-ink);
+  font-weight: 700;
+  cursor: default;
+}
+
+/* The zoom canvas scales layout via CSS `zoom`, so the scroll area shrinks too. */
+.org-canvas {
+  transition: none;
+}
 </style>

--- a/client/src/views/SearchEmployees.vue
+++ b/client/src/views/SearchEmployees.vue
@@ -94,6 +94,19 @@
             />
           </v-col>
 
+          <v-col cols="12" md="6">
+            <v-select
+              v-model="searchCriteria.jobLevel"
+              :items="appStore.formOptions.jobLevels"
+              label="Job Level"
+              variant="outlined"
+              density="compact"
+              clearable
+              prepend-inner-icon="mdi-stairs"
+              color="primary"
+            />
+          </v-col>
+
           <!-- Validation Message -->
           <v-col v-if="!hasValidInput && showValidationMessage" cols="12">
             <v-alert
@@ -195,7 +208,12 @@ import { ref, computed, reactive, onMounted } from "vue";
 import { useAppStore } from "../stores/app";
 import DataTable from "../components/DataTable.vue";
 import { exportToExcel } from "../modules/genericHelper";
-import type { Employee, EmploymentType, ActiveStatus } from "../types";
+import type {
+  Employee,
+  EmploymentType,
+  ActiveStatus,
+  JobLevel,
+} from "../types";
 
 const appStore = useAppStore();
 
@@ -213,6 +231,7 @@ interface SearchCriteria {
   status?: ActiveStatus;
   managerId?: string;
   employmentType?: EmploymentType;
+  jobLevel?: JobLevel;
 }
 
 // Initialize search criteria
@@ -223,6 +242,7 @@ const searchCriteria = reactive<SearchCriteria>({
   status: undefined,
   managerId: "",
   employmentType: undefined,
+  jobLevel: undefined,
 });
 
 // Computed options for dropdowns
@@ -248,7 +268,8 @@ const hasValidInput = computed(() => {
     (searchCriteria.position && searchCriteria.position.trim()) ||
     searchCriteria.status ||
     (searchCriteria.managerId && searchCriteria.managerId.trim()) ||
-    searchCriteria.employmentType
+    searchCriteria.employmentType ||
+    searchCriteria.jobLevel
   );
 });
 
@@ -325,6 +346,7 @@ const clearSearch = () => {
     status: undefined,
     managerId: "",
     employmentType: undefined,
+    jobLevel: undefined,
   });
 
   // Clear results and validation

--- a/server/app/models/employee.py
+++ b/server/app/models/employee.py
@@ -321,6 +321,7 @@ class SearchCriteria(BaseModel):
     status: Optional[ActiveStatus] = None
     manager_id: Optional[str] = Field(None, alias="managerId")
     employment_type: Optional[str] = Field(None, alias="employmentType")
+    job_level: Optional[str] = Field(None, alias="jobLevel")
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/server/app/services/bulk_service.py
+++ b/server/app/services/bulk_service.py
@@ -13,9 +13,15 @@ from app.models.bulk_operations import (
     BulkUpdateTrainingStatusRequest,
     BulkSchedulePerformanceReviewRequest,
 )
+from app.services.employee_service import EmployeeService
 
 
 class BulkService:
+    def __init__(self):
+        # Reuse the single-employee hierarchy validation so bulk and single paths
+        # enforce exactly the same rules.
+        self._employee_service = EmployeeService()
+
     async def bulk_assign_manager(self, request: BulkAssignManagerRequest) -> Dict:
         """Assign a manager to multiple employees."""
         db = await get_database()
@@ -39,6 +45,20 @@ class BulkService:
         for emp_id in request.employee_ids:
             try:
                 _id = ObjectId(emp_id)
+                employee = await db.employees.find_one({"_id": _id})
+                if not employee:
+                    failed_count += 1
+                    failed_ids.append(emp_id)
+                    continue
+
+                # Enforce the same hierarchy rules as single-employee assignment
+                # (manager seniority, status, employment type, no self-management).
+                await self._employee_service._validate_manager_constraints(
+                    db,
+                    {"managerId": request.manager_id, "jobLevel": employee.get("jobLevel")},
+                    exclude_id=_id,
+                )
+
                 result = await db.employees.update_one(
                     {"_id": _id},
                     {
@@ -121,15 +141,21 @@ class BulkService:
                     "updatedAt": datetime.utcnow(),
                 }
 
-                # If terminating, set termination date
+                # Keep terminationDate consistent across status transitions.
                 if request.new_status == "Terminated":
                     update_data["terminationDate"] = request.effective_date
+                elif request.new_status in ("Active", "On Leave", "Inactive"):
+                    update_data["terminationDate"] = None
 
                 result = await db.employees.update_one(
                     {"_id": _id},
                     {"$set": update_data}
                 )
                 if result.matched_count > 0:
+                    # Terminating a manager must re-home their reports (skip-level),
+                    # same as the single-employee path.
+                    if request.new_status == "Terminated":
+                        await self._employee_service._clear_reports_for_terminated(db, _id)
                     updated_count += 1
                 else:
                     failed_count += 1
@@ -159,6 +185,22 @@ class BulkService:
         for emp_id in request.employee_ids:
             try:
                 _id = ObjectId(emp_id)
+
+                manager_id = rehire_data.manager_id
+                manager_name = rehire_data.manager_name
+
+                # Rehiring as CEO: enforce the single-CEO rule and drop any manager.
+                if rehire_data.job_level == "CEO":
+                    await self._employee_service._assert_single_ceo(db, exclude_id=_id)
+                    manager_id, manager_name = None, None
+
+                # Enforce the same hierarchy rules as a normal hire/assignment.
+                await self._employee_service._validate_manager_constraints(
+                    db,
+                    {"managerId": manager_id, "jobLevel": rehire_data.job_level},
+                    exclude_id=_id,
+                )
+
                 result = await db.employees.update_one(
                     {"_id": _id},
                     {
@@ -170,8 +212,8 @@ class BulkService:
                             "jobLevel": rehire_data.job_level,
                             "salary": rehire_data.salary,
                             "employmentType": rehire_data.employment_type,
-                            "managerId": rehire_data.manager_id,
-                            "managerName": rehire_data.manager_name,
+                            "managerId": manager_id,
+                            "managerName": manager_name,
                             "updatedAt": datetime.utcnow(),
                         },
                         "$unset": {

--- a/server/app/services/employee_service.py
+++ b/server/app/services/employee_service.py
@@ -77,23 +77,80 @@ class EmployeeService:
         manager_status = manager_doc.get("status")
         if manager_status not in ["Active", "On Leave"]:
             raise ValueError("Manager must be Active or On Leave.")
+        manager_type = manager_doc.get("employmentType")
+        if manager_type not in ["Full-time", "Part-time"]:
+            raise ValueError("Manager must be a Full-time or Part-time employee.")
         manager_level = manager_doc.get("jobLevel")
         employee_level = employee_payload.get("jobLevel")
         if employee_level and self._job_level_rank(manager_level) < self._job_level_rank(employee_level):
             raise ValueError("Manager's job level must not be below the employee's level.")
-        # Prevent selecting self as manager
+        # Prevent self-management and circular reporting chains. Only relevant on
+        # update (on create the employee has no id yet and can't be an ancestor).
         if exclude_id is not None:
-            manager_doc_id = manager_doc.get("_id")
-            if isinstance(manager_doc_id, ObjectId):
-                manager_doc_id = str(manager_doc_id)
-            if manager_id == str(exclude_id) or manager_doc_id == str(exclude_id):
+            employee_id_str = str(exclude_id)
+            manager_doc_id = str(manager_doc.get("_id"))
+            if manager_id == employee_id_str or manager_doc_id == employee_id_str:
                 raise ValueError("An employee cannot be their own manager.")
 
+            # Walk up the proposed manager's chain; if we reach the employee being
+            # edited, this assignment would close a loop. (Equal-level reporting is
+            # allowed, so a cycle is otherwise possible without this check.)
+            current = manager_doc.get("managerId")
+            seen = {manager_id, manager_doc_id}
+            steps = 0
+            while current and current not in seen and steps < 10000:
+                if current == employee_id_str:
+                    raise ValueError(
+                        "This assignment would create a circular reporting relationship."
+                    )
+                seen.add(current)
+                steps += 1
+                node = (
+                    await db.employees.find_one(
+                        {"_id": ObjectId(current)}, {"managerId": 1}
+                    )
+                    if ObjectId.is_valid(current)
+                    else await db.employees.find_one(
+                        {"_id": current}, {"managerId": 1}
+                    )
+                )
+                current = (node or {}).get("managerId")
+
+    async def _assert_level_outranks_reports(self, db, employee_id: ObjectId, new_level: str) -> None:
+        """A level change must still outrank the employee's existing direct reports."""
+        new_rank = self._job_level_rank(new_level)
+        cursor = db.employees.find({"managerId": str(employee_id)}, {"jobLevel": 1})
+        async for rep in cursor:
+            if self._job_level_rank(rep.get("jobLevel")) > new_rank:
+                raise ValueError(
+                    "New job level is below an existing direct report's level. "
+                    "Reassign that person's reports before changing this level."
+                )
+
     async def _clear_reports_for_terminated(self, db, employee_id: ObjectId) -> None:
+        """Re-home a terminated manager's reports to the skip-level manager.
+
+        When a manager is terminated their reports move up to the terminated
+        manager's own manager (skip-level), keeping the org tree intact. If the
+        terminated person had no manager (org root), the reports are detached.
+        """
         manager_id_str = str(employee_id)
+        terminated = await db.employees.find_one({"_id": employee_id})
+        skip_manager_id = (terminated or {}).get("managerId")
+
+        update_fields = {"managerId": None, "managerName": None}
+        if skip_manager_id and ObjectId.is_valid(skip_manager_id):
+            skip_manager = await db.employees.find_one({"_id": ObjectId(skip_manager_id)})
+            # Only re-home to a manager who is still active.
+            if skip_manager and skip_manager.get("status") in ["Active", "On Leave"]:
+                update_fields = {
+                    "managerId": skip_manager_id,
+                    "managerName": skip_manager.get("fullName", ""),
+                }
+
         await db.employees.update_many(
             {"managerId": manager_id_str},
-            {"$set": {"managerId": None, "managerName": None}}
+            {"$set": update_fields},
         )
 
     async def get_employees(
@@ -147,6 +204,8 @@ class EmployeeService:
             query["managerId"] = criteria.manager_id
         if criteria.employment_type:
             query["employmentType"] = criteria.employment_type
+        if criteria.job_level:
+            query["jobLevel"] = criteria.job_level
 
         cursor = db.employees.find(query)
         docs = await cursor.to_list(length=None)
@@ -161,23 +220,37 @@ class EmployeeService:
         return [Employee(**d) for d in docs]
 
     async def get_managers(self) -> List[Employee]:
-        """Get all employees who are managers.
-        
-        Managers are identified by either:
-        1. Having direct reports
-        2. Having a manager-level job level (Manager, Director, VP, C-Level, CEO)
+        """Get all employees who are eligible to be managers.
+
+        A manager is identified by either:
+        1. Having at least one direct report (someone points to them via managerId), or
+        2. Having a manager-level job level (Manager, Director, VP, C-Level, CEO).
+
+        In both cases they must also be Active/On Leave and Full-time/Part-time
+        (the canonical eligibility rules).
         """
         db = await get_database()
-        
-        # Query for employees who are managers based on job level or have direct reports
+
+        # managerId is the single source of truth for reporting relationships, so
+        # derive "has reports" from it rather than the denormalized directReports
+        # array (which is not maintained on write).
+        ids_with_reports = await db.employees.distinct(
+            "managerId", {"managerId": {"$nin": [None, ""]}}
+        )
+        # Stored managerIds are strings of the manager's _id; convert to ObjectId.
+        object_ids_with_reports = [
+            ObjectId(mid) for mid in ids_with_reports if mid and ObjectId.is_valid(mid)
+        ]
+
         query = {
             "$or": [
-                {"directReports": {"$exists": True, "$ne": [], "$ne": None}},
-                {"jobLevel": {"$in": ["Manager", "Director", "VP", "C-Level", "CEO"]}}
+                {"_id": {"$in": object_ids_with_reports}},
+                {"jobLevel": {"$in": ["Manager", "Director", "VP", "C-Level", "CEO"]}},
             ],
-            "status": {"$in": ["Active", "On Leave"]}  # Only active managers
+            "status": {"$in": ["Active", "On Leave"]},
+            "employmentType": {"$in": ["Full-time", "Part-time"]},
         }
-        
+
         cursor = db.employees.find(query).sort("fullName", 1)
         docs = await cursor.to_list(length=None)
         docs = [self._normalize_employee_doc(d) for d in docs]
@@ -270,17 +343,44 @@ class EmployeeService:
             # No fields to update, just return current
             return await self.get_employee(employee_id)
 
+        current = await db.employees.find_one({"_id": _id})
+        if not current:
+            raise ValueError("Employee not found")
+
         # CEO constraints
         if update_dict.get("jobLevel") == "CEO":
             await self._assert_single_ceo(db, exclude_id=_id)
             update_dict = self._apply_ceo_constraints(update_dict)
 
-        # Manager constraints
-        await self._validate_manager_constraints(db, update_dict, exclude_id=_id)
+        # Manager constraints — validate the *effective* manager/level by merging
+        # the update over the current doc, so a partial update (e.g. level only)
+        # is still checked against the existing manager.
+        effective = {
+            "managerId": update_dict.get("managerId", current.get("managerId")),
+            "jobLevel": update_dict.get("jobLevel", current.get("jobLevel")),
+        }
+        await self._validate_manager_constraints(db, effective, exclude_id=_id)
 
-        # Handle termination: if status becomes Terminated, clear manager from reports
-        if update_dict.get("status") == "Terminated":
+        # A level change must still outrank the employee's existing direct reports.
+        if "jobLevel" in update_dict:
+            await self._assert_level_outranks_reports(db, _id, update_dict["jobLevel"])
+
+        # Status transitions: keep terminationDate and reports consistent.
+        new_status = update_dict.get("status")
+        if new_status == "Terminated":
+            if not update_dict.get("terminationDate"):
+                update_dict["terminationDate"] = datetime.utcnow().isoformat()
             await self._clear_reports_for_terminated(db, _id)
+        elif new_status in ("Active", "On Leave", "Inactive"):
+            # Reactivating: drop any stale termination date.
+            update_dict["terminationDate"] = None
+
+        # Keep reports' denormalized managerName in sync when this person renames.
+        if "fullName" in update_dict and update_dict["fullName"] != current.get("fullName"):
+            await db.employees.update_many(
+                {"managerId": str(_id)},
+                {"$set": {"managerName": update_dict["fullName"]}},
+            )
 
         update_dict["updatedAt"] = datetime.utcnow()
 

--- a/server/scripts/reset_db.py
+++ b/server/scripts/reset_db.py
@@ -1,0 +1,47 @@
+"""Reset the database to a clean slate.
+
+Clears the `employees` and `users` collections, then re-seeds the single default
+login account so the app remains usable after the wipe. Used to rebuild the org
+from scratch under the canonical hierarchy rules.
+
+DESTRUCTIVE — removes all employees and users. Run intentionally:
+  python -m scripts.reset_db
+"""
+
+import asyncio
+
+from app.database import connect_to_mongo, close_mongo_connection, get_database
+from app.models.user import UserCreate
+from app.services.auth_service import create_user
+
+# Default demo login surfaced on the client login page (Login.vue).
+DEFAULT_USER = UserCreate(
+    email="test@example.com",
+    password="Test123!",
+    full_name="Test User",
+    is_admin=True,
+)
+
+
+async def main() -> int:
+    await connect_to_mongo()
+    try:
+        db = await get_database()
+
+        emp_result = await db.employees.delete_many({})
+        user_result = await db.users.delete_many({})
+        print(f"Deleted {emp_result.deleted_count} employees")
+        print(f"Deleted {user_result.deleted_count} users")
+
+        # Re-seed the default login account (password hashed via the app's bcrypt
+        # helper so it matches authenticate_user).
+        created = await create_user(db, DEFAULT_USER)
+        print(f"Seeded default user: {created.email}")
+
+        return 0
+    finally:
+        await close_mongo_connection()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/server/scripts/seed_employees.py
+++ b/server/scripts/seed_employees.py
@@ -1,0 +1,232 @@
+"""Seed a realistic org with hire dates across the last 3 months.
+
+Creates employees top-down through EmployeeService.create_employee so every
+record passes the canonical hierarchy validation (manager seniority, eligible
+status/employment type, single CEO, no cycles) and gets a generated employeeId.
+
+Dates are coherent with the hierarchy: the CEO is hired first (window start) and
+every employee is hired strictly after their manager.
+
+Usage (run after scripts.reset_db):
+  python -m scripts.seed_employees
+"""
+
+import asyncio
+import random
+from datetime import date, timedelta
+
+from app.database import connect_to_mongo, close_mongo_connection, get_database
+from app.models.employee import EmployeeCreate
+from app.services.employee_service import EmployeeService
+
+random.seed(7)
+
+# Hire-date window: the last ~3 months ending today.
+WINDOW_START = date(2026, 3, 10)
+TODAY = date(2026, 6, 10)
+
+# Department -> business unit.
+BUSINESS_UNIT = {
+    "Executive": "Executive",
+    "Engineering": "Technology",
+    "Product": "Technology",
+    "Sales": "Revenue",
+    "Marketing": "Revenue",
+    "Finance": "Operations",
+    "Operations": "Operations",
+    "Human Resources": "Operations",
+}
+
+CITIES = [
+    ("Austin", "TX"),
+    ("Denver", "CO"),
+    ("Seattle", "WA"),
+    ("Chicago", "IL"),
+    ("Boston", "MA"),
+    ("Atlanta", "GA"),
+]
+
+# (key, first, last, dept, position, level, type, status, location,
+#  salary, paygrade, perf, training, bg, benefits, manager_key)
+PEOPLE = [
+    ("ceo", "Patricia", "Vance", "Executive", "Chief Executive Officer", "CEO",
+     "Full-time", "Active", "Hybrid", 450000, "E9", "Exceeds Expectations",
+     "Completed", "Completed", "Yes", None),
+
+    ("cto", "Daniel", "Okafor", "Engineering", "Chief Technology Officer", "C-Level",
+     "Full-time", "Active", "Hybrid", 330000, "E8", "Exceeds Expectations",
+     "Completed", "Completed", "Yes", "ceo"),
+    ("cfo", "Maria", "Santos", "Finance", "Chief Financial Officer", "C-Level",
+     "Full-time", "Active", "Office", 320000, "E8", "Meets Expectations",
+     "Completed", "Completed", "Yes", "ceo"),
+    ("coo", "James", "Whitfield", "Operations", "Chief Operating Officer", "C-Level",
+     "Full-time", "Active", "Hybrid", 325000, "E8", "Exceeds Expectations",
+     "Completed", "Completed", "Yes", "ceo"),
+
+    ("vp_eng", "Aisha", "Khan", "Engineering", "VP of Engineering", "VP",
+     "Full-time", "Active", "Hybrid", 245000, "E7", "Exceeds Expectations",
+     "Completed", "Completed", "Yes", "cto"),
+    ("vp_prod", "Robert", "Lang", "Product", "VP of Product", "VP",
+     "Full-time", "Active", "Hybrid", 240000, "E7", "Meets Expectations",
+     "Completed", "Completed", "Yes", "cto"),
+    ("vp_sales", "Elena", "Rossi", "Sales", "VP of Sales", "VP",
+     "Full-time", "Active", "Office", 238000, "E7", "Exceeds Expectations",
+     "Completed", "Completed", "Yes", "coo"),
+    ("vp_people", "Marcus", "Lee", "Human Resources", "VP of People", "VP",
+     "Full-time", "Active", "Hybrid", 225000, "E7", "Meets Expectations",
+     "Completed", "Completed", "Yes", "coo"),
+
+    ("dir_eng", "Priya", "Nair", "Engineering", "Director of Engineering", "Director",
+     "Full-time", "Active", "Hybrid", 185000, "E6", "Exceeds Expectations",
+     "Completed", "Completed", "Yes", "vp_eng"),
+    ("dir_prod", "Tom", "Becker", "Product", "Director of Product", "Director",
+     "Full-time", "Active", "Hybrid", 178000, "E6", "Meets Expectations",
+     "Completed", "Completed", "Yes", "vp_prod"),
+    ("dir_sales", "Sofia", "Mendez", "Sales", "Director of Sales", "Director",
+     "Full-time", "Active", "Office", 175000, "E6", "Meets Expectations",
+     "In Progress", "Completed", "Yes", "vp_sales"),
+    ("dir_mktg", "Kevin", "Zhang", "Marketing", "Director of Marketing", "Director",
+     "Full-time", "Active", "Remote", 172000, "E6", "Meets Expectations",
+     "Completed", "Completed", "Yes", "vp_sales"),
+
+    ("mgr_eng1", "Hannah", "Cole", "Engineering", "Engineering Manager", "Manager",
+     "Full-time", "Active", "Hybrid", 145000, "E5", "Exceeds Expectations",
+     "Completed", "Completed", "Yes", "dir_eng"),
+    ("mgr_eng2", "Omar", "Haddad", "Engineering", "Engineering Manager", "Manager",
+     "Full-time", "Active", "Remote", 142000, "E5", "Meets Expectations",
+     "Completed", "Completed", "Yes", "dir_eng"),
+    ("mgr_prod", "Grace", "Kim", "Product", "Product Manager", "Manager",
+     "Full-time", "Active", "Hybrid", 138000, "E5", "Meets Expectations",
+     "In Progress", "Completed", "Yes", "dir_prod"),
+    ("mgr_sales", "Lucas", "Moreau", "Sales", "Sales Manager", "Manager",
+     "Full-time", "Active", "Office", 135000, "E5", "Meets Expectations",
+     "Completed", "Completed", "Yes", "dir_sales"),
+    ("mgr_hr", "Nina", "Patel", "Human Resources", "HR Manager", "Manager",
+     "Full-time", "Active", "Hybrid", 132000, "E5", "Meets Expectations",
+     "Completed", "Completed", "Yes", "vp_people"),
+
+    ("lead_eng", "Ethan", "Brooks", "Engineering", "Lead Engineer", "Lead",
+     "Full-time", "Active", "Remote", 132000, "E5", "Meets Expectations",
+     "Completed", "Completed", "Yes", "mgr_eng1"),
+    ("sr_eng1", "Mia", "Tanaka", "Engineering", "Senior Engineer", "Senior",
+     "Full-time", "On Leave", "Remote", 122000, "E4", "Meets Expectations",
+     "Completed", "Completed", "Yes", "lead_eng"),
+    ("sr_eng2", "Carlos", "Vega", "Engineering", "Senior Engineer", "Senior",
+     "Contract", "Active", "Remote", 118000, "E4", "Meets Expectations",
+     "In Progress", "Completed", "No", "mgr_eng2"),
+    ("mid_eng", "Olivia", "Frost", "Engineering", "Software Engineer", "Mid",
+     "Part-time", "Active", "Hybrid", 92000, "E3", "Meets Expectations",
+     "In Progress", "Completed", "Yes", "lead_eng"),
+    ("entry_eng", "Noah", "Schmidt", "Engineering", "Junior Engineer", "Entry",
+     "Intern", "Active", "Office", 60000, "E1", "Unrated",
+     "Not Started", "In Progress", "No", "mgr_eng1"),
+
+    ("sr_prod", "Ava", "Nguyen", "Product", "Senior Product Analyst", "Senior",
+     "Full-time", "Active", "Hybrid", 115000, "E4", "Meets Expectations",
+     "Completed", "Completed", "Yes", "mgr_prod"),
+    ("mid_prod", "Liam", "Walsh", "Product", "Product Analyst", "Mid",
+     "Full-time", "Active", "Remote", 94000, "E3", "Meets Expectations",
+     "In Progress", "Completed", "Yes", "mgr_prod"),
+
+    ("sr_sales", "Isabella", "Conti", "Sales", "Senior Account Executive", "Senior",
+     "Full-time", "Active", "Office", 112000, "E4", "Exceeds Expectations",
+     "Completed", "Completed", "Yes", "mgr_sales"),
+    ("mid_sales", "Jack", "Murphy", "Sales", "Account Executive", "Mid",
+     "Full-time", "Active", "Office", 90000, "E3", "Meets Expectations",
+     "In Progress", "Completed", "Yes", "mgr_sales"),
+
+    ("mid_mktg", "Chloe", "Dubois", "Marketing", "Marketing Specialist", "Mid",
+     "Full-time", "Active", "Remote", 88000, "E3", "Meets Expectations",
+     "Completed", "Completed", "Yes", "dir_mktg"),
+
+    ("entry_hr", "Ryan", "Cooper", "Human Resources", "HR Coordinator", "Entry",
+     "Full-time", "Active", "Office", 68000, "E2", "Unrated",
+     "In Progress", "Completed", "Yes", "mgr_hr"),
+]
+
+
+def pick_hire_date(manager_date):
+    if manager_date is None:
+        return WINDOW_START
+    d = manager_date + timedelta(days=random.randint(3, 9))
+    return min(d, TODAY)
+
+
+async def main() -> int:
+    await connect_to_mongo()
+    service = EmployeeService()
+    # key -> {id, name, email, hire}
+    created = {}
+    try:
+        for (
+            key, first, last, dept, position, level, emp_type, status, location,
+            salary, paygrade, perf, training, bg, benefits, mgr_key,
+        ) in PEOPLE:
+            mgr = created.get(mgr_key) if mgr_key else None
+            hire = pick_hire_date(mgr["hire"] if mgr else None)
+            hire_str = hire.isoformat()
+            full = f"{first} {last}"
+            slug = f"{first.lower()}.{last.lower()}"
+            city, st = CITIES[len(created) % len(CITIES)]
+
+            payload = {
+                "status": status,
+                "firstName": first,
+                "lastName": last,
+                "fullName": full,
+                "personalEmail": f"{slug}@gmail.com",
+                "workEmail": f"{slug}@company.com",
+                "phoneNumber": f"+1-555-{random.randint(200, 999)}-{random.randint(1000, 9999)}",
+                "emergencyContactName": f"{last} Family",
+                "emergencyContactPhone": f"+1-555-{random.randint(200, 999)}-{random.randint(1000, 9999)}",
+                "address": f"{random.randint(100, 9999)} Main St",
+                "city": city,
+                "state": st,
+                "country": "United States",
+                "department": dept,
+                "position": position,
+                "jobLevel": level,
+                "employmentType": emp_type,
+                "workLocation": location,
+                "managerId": mgr["id"] if mgr else None,
+                "managerName": mgr["name"] if mgr else None,
+                "businessUnit": BUSINESS_UNIT.get(dept),
+                "hireDate": hire_str,
+                "probationEndDate": (hire + timedelta(days=90)).isoformat(),
+                "salary": float(salary),
+                "currency": 840,
+                "paygrade": paygrade,
+                "benefitsEligible": benefits,
+                "performanceRating": perf,
+                "trainingStatus": training,
+                "developmentNotes": f"Onboarding plan in place for {first}.",
+                "nextReviewDate": (hire + timedelta(days=180)).isoformat(),
+                "backgroundCheckStatus": bg,
+                "docType": "employee",
+                "source": "HR",
+                "hrAssignment": {
+                    "assignedTo": "Unassigned",
+                    "assignedDate": hire_str,
+                    "managerEmail": mgr["email"] if mgr else None,
+                    "managerAssignDate": hire_str if mgr else None,
+                },
+            }
+
+            emp = await service.create_employee(EmployeeCreate(**payload))
+            created[key] = {
+                "id": emp.id,
+                "name": full,
+                "email": payload["workEmail"],
+                "hire": hire,
+            }
+            print(f"  {hire_str}  {level:<8} {full} ({dept})"
+                  + (f" -> {mgr['name']}" if mgr else "  [org root]"))
+
+        print(f"\nSeeded {len(created)} employees from {WINDOW_START} to {TODAY}.")
+        return 0
+    finally:
+        await close_mongo_connection()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
Establish one canonical hierarchy and apply it consistently across the UI,
dialogs, and API; fix a cluster of state-transition data-integrity bugs; and
rework the org chart and forms for usability.

Hierarchy rules (single source of truth)
- Add client/src/constants/hierarchy.ts (JOB_LEVELS, jobLevelRank, canManage,
  isEligibleManagerType, getEligibleManagers); derive the schema enum, store
  form options, OrgChart ranking, and JobLevelChart order from it.
- Manager eligibility = equal-or-higher level, Active/On-Leave, Full-time/
  Part-time, no self/cycle, single CEO. Applied uniformly in EmployeeForm and
  all bulk dialogs (AssignManager, RehireEmployee, SchedulePerformanceReview).
- Allow cross-department reporting; surface same-department managers first.

Backend parity & integrity
- Validate manager constraints in create, update, and bulk paths via one shared
  validator; add transitive cycle detection and the employment-type rule.
- Validate level changes against the existing manager and existing reports
  (block invalid promotions/demotions).
- Re-home reports to the skip-level manager on termination (single + bulk);
  keep terminationDate and managerName consistent across status transitions.
- Fix get_managers query (drop duplicate-key bug, derive "has reports" from
  managerId, filter by employment type).

Bulk actions
- Skip no-op / invalid targets (already-assigned manager, same status/type,
  non-terminated rehire) with inline warnings; disable submit when all skipped.
- Clear bulk selection on route change so it no longer persists across views.

Org chart
- Add collapse/expand with sensible default depth, expand/collapse all, zoom +
  fit-to-width, and focus/re-root with breadcrumb to tame horizontal sprawl.
- Fix connector-line alignment (ResizeObserver + layout-offset measurement,
  robust to nested expansion and zoom).

UI polish
- Fix global rule that rendered all helper text as errors (hints now grey,
  errors red only on invalid fields).
- De-chrome dialogs (lighter selected-employees summary, flat sections,
  consistent footers); fix top-bar title; center loading overlay.
- Add "By Job Level" view + job-level search filter; seniority ordering in
  tables.

Tooling
- Add scripts/reset_db.py and scripts/seed_employees.py (dev utilities).